### PR TITLE
Update toc.yml

### DIFF
--- a/en/toc.yml
+++ b/en/toc.yml
@@ -4,6 +4,6 @@
   href: manual/
   homepage: manual/index.md
 - name: API
-  href: api/
+  href: api/index.md
 - name: Release Notes
   href: ReleaseNotes/ReleaseNotes.md


### PR DESCRIPTION
API link arbitrary goes to `Xenko` namespace page. I think it is better to go the index.