### PR TITLE
Added detailed comparison of Unity and Xenko Transform components

### DIFF
--- a/en/manual/xenko-for-unity-developers/index.md
+++ b/en/manual/xenko-for-unity-developers/index.md
@@ -617,9 +617,9 @@ public override void Start()
     // Initialization of the script.
     List<Entity> car = CarPrefab.Instantiate();
     SceneSystem.SceneInstance.RootScene.Entities.AddRange(car);
-    car.First().Transform.Position = SpawnPosition;
-    car.First().Transform.Rotation = SpawnRotation;
-    car.First().Name = "MyNewEntity";
+    car[0].Transform.Position = SpawnPosition;
+    car[0].Transform.Rotation = SpawnRotation;
+    car[0].Name = "MyNewEntity";
 }
 ```
 


### PR DESCRIPTION
This PR adds a more detailed comparison of Unity and Xenko Transform components in the "Xenko for Unity Developers" page, based on the Discord discussion a few days back. It also changes some of the code samples to use explicit type declarations (instead of "var") where the return type isn't obvious to people not familiar with the engine.

As far as I can tell, there is no way to get _just_ the world rotation or scale from the WorldMatrix, so I have left those table cells as N/A.

I'm new to pull requests so if I've messed anything up give me a heads up and I'll be happy to fix it.