### PR TITLE
Rewrite part of trigger sample to be clearer.

### DIFF
--- a/en/manual/physics/script-a-trigger.md
+++ b/en/manual/physics/script-a-trigger.md
@@ -183,13 +183,7 @@ Let's write a script to change the size of the ball when it enters the trigger.
                     otherCollider.Entity.Transform.Scale = new Vector3(2.0f, 2.0f, 2.0f);
 
                     // 2. Wait for the entity to exit the trigger
-                    Collision collision;
-
-                    do
-                    {
-                        collision = await trigger.CollisionEnded();
-                    }
-                    while (collision != firstCollision);
+                    await firstCollision.Ended();
 
                     otherCollider.Entity.Transform.Scale= new Vector3(1.0f, 1.0f, 1.0f);
                 }
@@ -260,19 +254,15 @@ namespace TransformTrigger
                 // 1. Wait for an entity to collide with the trigger
                 var firstCollision = await trigger.NewCollision();
 
-                var otherCollider = trigger == firstCollision.ColliderA ? firstCollision.ColliderB : firstCollision.ColliderA;
+                var otherCollider = trigger == firstCollision.ColliderA
+                    ? firstCollision.ColliderB
+                    : firstCollision.ColliderA;
                     
                 // 2. Change the material on the entity
                 otherCollider.Entity.Get<ModelComponent>().Materials[0] = material2;
                 
                 // 3. Wait for the entity to exit the trigger
-                Collision collision;
-
-                do
-                {
-                    collision = await trigger.CollisionEnded();
-                }
-                while (collision != firstCollision);
+                await firstCollision.Ended();
 
                 // 4. Change the material back to the original one
                 otherCollider.Entity.Get<ModelComponent>().Materials[0] = material1;


### PR DESCRIPTION
I found myself digging through the trigger pages myself when putting together a trigger sample of my own, and realised that a specific snippet on the script a trigger page had a direct equivalent as a method in the `Collision` class itself:

https://github.com/xenko3d/xenko/blob/951335d9d421889a7459130f3e68436c62d8a02c/sources/engine/Xenko.Physics/Collision.cs#L71-L79

Unfortunately the snippet doesn't embed but you can see there what I mean :)