### PR TITLE
Fix odd formatting on triggers tutorial page.

### DIFF
--- a/en/manual/physics/triggers.md
+++ b/en/manual/physics/triggers.md
@@ -24,9 +24,11 @@ You can see when something enters the trigger using the following code:
 
 ```cs
 // Wait for an entity to collide with the trigger
-                var firstCollision = await trigger.NewCollision();
+var firstCollision = await trigger.NewCollision();
 
-                var otherCollider = trigger == firstCollision.ColliderA ? firstCollision.ColliderB : firstCollision.ColliderA;
+var otherCollider = trigger == firstCollision.ColliderA
+    ? firstCollision.ColliderB
+    : firstCollision.ColliderA;
 ```
 
 Alternatively, directly access the `TrackingHashSet`:


### PR DESCRIPTION
It was previously indented a whole lot for no particular reason.
Also formatted fetching the other collider like all other samples do.