### PR TITLE
Fix typo in section related to device debug flag

### DIFF
--- a/en/manual/troubleshooting/profiling.md
+++ b/en/manual/troubleshooting/profiling.md
@@ -187,7 +187,7 @@ RenderDoc is a free MIT licensed stand-alone graphics debugger that allows quick
 2. Optional: in your executable project (Windows), locate `game.Run();` and insert the following code just before:
 
    ```cs
-   game.GraphicsDeviceManager.Preferred.DeviceCreationFlags |= DeviceCreationFlags.Debug;
+   game.GraphicsDeviceManager.DeviceCreationFlags |= DeviceCreationFlags.Debug;
    ```
 
    This will enable render pass markers during rendering.


### PR DESCRIPTION
The `Preferred` member does not actually exist on the `GraphicsDeviceManager`, just realised as soon as I'd checked the docs page to try and use it myself to debug something 👍 