### PR TITLE
Rearranged the manual index page

### DIFF
--- a/en/manual/index.md
+++ b/en/manual/index.md
@@ -4,45 +4,9 @@
 
 These pages contain information about how to use Stride, an open-source C# game engine.
 
-> [!Note]
-> The Stride manual is under construction and is regularly updated with new content. Follow [Stride on X](https://x.com/stridedotnet?s=20) for documentation updates.
+## Stride community toolkit
 
-## Latest documentation
-
-### Recent updates
-
-#### Manual
-
-- <span class="badge text-bg-success">New</span> [Glossary](glossary/index.md) - New glossary section added 
-
-### Previous updates
-
-#### Manual
-- <span class="badge text-bg-info">Updated</span> [Graphics - Materials - Materials for developers ](graphics/materials/materials-for-developers.md) - Modifying parameters at runtime added
-- <span class="badge text-bg-success">New</span> [Scripts](scripts/best-practice.md) - Best Practices docs added
-- <span class="badge text-bg-success">New</span> [Physics](physics/index.md) - Bepu Physics docs added
-- <span class="badge text-bg-info">Updated</span> [Bullet Physics](physics-bullet/index.md) - Bullet Physics docs moved
-- <span class="badge text-bg-info">Updated</span> [Files and Folders](files-and-folders/distribute-a-game.md) - Game distribution steps updated
-- <span class="badge text-bg-info">Updated</span> [Scripts - Types of script](scripts/types-of-script.md) - Asynchronous script example improved
-- <span class="badge text-bg-success">New</span> [Scripts - Gizmos](scripts/gizmos.md) - Description and example of the Flexible Processing system
-- <span class="badge text-bg-success">New</span> [ECS - Flexible Processing](engine/entity-component-system/flexible-processing.md) - Description and example of the Flexible Processing system
-- <span class="badge text-bg-info">Updated</span> [Linux - Setup and requirements](platforms/linux/setup-and-requirements.md) - Fedora OS option added
-- <span class="badge text-bg-success">New</span> [Scripts - Serialization](scripts/serialization.md) - Explanation of serialization
-- <span class="badge text-bg-info">Updated</span> [Scripts - Public properties and fields](scripts/public-properties-and-fields.md) - Content improvements and additions
-- <span class="badge text-bg-success">New</span> [Engine - Entity Component model - Usage](engine/entity-component-system/usage.md) - Explanation of ECS usage
-- <span class="badge text-bg-info">Updated</span> [Engine - Entity Component model](engine/entity-component-system/index.md) - Content improvements
-- <span class="badge text-bg-info">Updated</span> [Stride for Unity® developers](stride-for-unity-developers/index.md) - Content improvements
-
-#### Tutorials
-
-- <span class="badge text-bg-info">Updated</span> [Tutorials](../tutorials/index.md) - Quick Tutorials section added
-- <span class="badge text-bg-info">Updated</span> [Tutorials](../tutorials/index.md) - Added lesson counts and total length
-
-#### Contributing
-
-- <span class="badge text-bg-info">Updated</span> [Contributing - Roadmap](../contributors/roadmap.md) - GitHub Project - Roadmap link added
-- <span class="badge text-bg-success">New</span> [Contributing - Core Team](../contributors/core-team.md) - The Stride core team
-- <span class="badge text-bg-info">Updated</span> [Contributing - Roadmap](../contributors/roadmap.md) - Status added 
+Check out our [Stride community toolkit](https://stride3d.github.io/stride-community-toolkit/index.html) for additional helpers and extensions.
 
 ## Improve this documentation
 
@@ -50,6 +14,34 @@ The Stride documentation is open source, so anyone can edit it. If you find a mi
 
 To edit any page of this manual, click the **Edit this page** link at the bottom. Please make sure to follow the [writing guidelines](../contributors/documentation/index.md).
 
-## Stride community toolkit
+## Latest documentation
 
-Check out our [Stride community toolkit](https://stride3d.github.io/stride-community-toolkit/index.html) for additional helpers and extensions.
+**Recent updates**
+
+- Manual
+  - <span class="badge text-bg-success">New</span> [Glossary](glossary/index.md) - New glossary section added 
+
+**Previous updates**
+
+- Manual
+  - <span class="badge text-bg-info">Updated</span> [Graphics - Materials - Materials for developers ](graphics/materials/materials-for-developers.md) - Modifying parameters at runtime added
+  - <span class="badge text-bg-success">New</span> [Scripts](scripts/best-practice.md) - Best Practices docs added
+  - <span class="badge text-bg-success">New</span> [Physics](physics/index.md) - Bepu Physics docs added
+  - <span class="badge text-bg-info">Updated</span> [Bullet Physics](physics-bullet/index.md) - Bullet Physics docs moved
+  - <span class="badge text-bg-info">Updated</span> [Files and Folders](files-and-folders/distribute-a-game.md) - Game distribution steps updated
+  - <span class="badge text-bg-info">Updated</span> [Scripts - Types of script](scripts/types-of-script.md) - Asynchronous script example improved
+  - <span class="badge text-bg-success">New</span> [Scripts - Gizmos](scripts/gizmos.md) - Description and example of the Flexible Processing system
+  - <span class="badge text-bg-success">New</span> [ECS - Flexible Processing](engine/entity-component-system/flexible-processing.md) - Description and example of the Flexible Processing system
+  - <span class="badge text-bg-info">Updated</span> [Linux - Setup and requirements](platforms/linux/setup-and-requirements.md) - Fedora OS option added
+  - <span class="badge text-bg-success">New</span> [Scripts - Serialization](scripts/serialization.md) - Explanation of serialization
+  - <span class="badge text-bg-info">Updated</span> [Scripts - Public properties and fields](scripts/public-properties-and-fields.md) - Content improvements and additions
+  - <span class="badge text-bg-success">New</span> [Engine - Entity Component model - Usage](engine/entity-component-system/usage.md) - Explanation of ECS usage
+  - <span class="badge text-bg-info">Updated</span> [Engine - Entity Component model](engine/entity-component-system/index.md) - Content improvements
+  - <span class="badge text-bg-info">Updated</span> [Stride for Unity® developers](stride-for-unity-developers/index.md) - Content improvements
+- Tutorials
+  - <span class="badge text-bg-info">Updated</span> [Tutorials](../tutorials/index.md) - Quick Tutorials section added
+  - <span class="badge text-bg-info">Updated</span> [Tutorials](../tutorials/index.md) - Added lesson counts and total length
+- Contributing
+  - <span class="badge text-bg-info">Updated</span> [Contributing - Roadmap](../contributors/roadmap.md) - GitHub Project - Roadmap link added
+  - <span class="badge text-bg-success">New</span> [Contributing - Core Team](../contributors/core-team.md) - The Stride core team
+  - <span class="badge text-bg-info">Updated</span> [Contributing - Roadmap](../contributors/roadmap.md) - Status added


### PR DESCRIPTION
I rearranged the manual index page a bit, so that the changelog won't obscure the "community toolkit" and "contributing" sections. Also removed a note to follow the X account as it's inactive and probably won't notify of updates to the documentation.