### PR TITLE
ci:  Update DocFX checkout config

### DIFF
--- a/.github/workflows/stride-docs-test-build.yml
+++ b/.github/workflows/stride-docs-test-build.yml
@@ -59,8 +59,9 @@ jobs:
       with:
         repository: dotnet/docfx
         # Tested commit
-        ref: 917cda8
+        ref: 917cda864650279e0bbe50b852cb98601e5efa4d
         path: docfx-build
+        fetch-depth: 0
 
     - name: Restore npm dependencies
       run: npm install


### PR DESCRIPTION
ci: stride-docs-test-build.yml - Update DocFX checkout config

- Set ref to full commit hash 917cda864650279e0bbe50b852cb98601e5efa4d for precise version control
- Add fetch-depth: 0 to fetch full git history, supporting operations that require complete commit data

#### PR Classification
Workflow improvement to ensure reliable DocFX builds and history access.

#### PR Summary
This pull request updates the DocFX checkout step in the stride-docs-test-build.yml workflow to use a full commit hash and fetch the complete commit history.
- stride-docs-test-build.yml: Changes DocFX ref from a short to a full commit hash and sets fetch-depth: 0 for full history retrieval.
