### PR TITLE
ci: Update workflows and DocFX build process

### DIFF
--- a/.github/workflows/stride-docs-github.yml
+++ b/.github/workflows/stride-docs-github.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
     - name: .NET SDK Setup
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
 
     # Checkout the Stride Docs repository from the branch that triggered the workflow
     - name: Checkout Stride Docs
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         path: ${{ env.DOCS_PATH }}
         lfs: true
@@ -36,25 +36,55 @@ jobs:
 
     # Checkout the Stride repository from the default branch
     - name: Checkout Stride (note the LFS)
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: stride3d/stride
         token: ${{ secrets.GITHUB_TOKEN }}
         path: stride
         lfs: true
+        ref: master
 
-    - name: Install DocFX
+    # Temporary solution till the new docfx is available
+    - name: Checkout DocFX
+      uses: actions/checkout@v6
+      with:
+        repository: dotnet/docfx
+        # Tested commit
+        ref: 917cda864650279e0bbe50b852cb98601e5efa4d
+        path: docfx-build
+        fetch-depth: 0
+
+    - name: Restore npm dependencies
+      run: npm install
+      working-directory:  docfx-build/templates
+
+    - name: Build site templates
+      run: npm run build
+      working-directory:  docfx-build/templates
+
+    - name: Build DocFX from PR
+      run: dotnet pack src/docfx -c Release /p:Version=2.9-stride -o drop/nuget
+      working-directory: docfx-build
+      shell: pwsh
+
+    - name: Build Install DocFX
+      run: dotnet tool install -g docfx --version 2.9-stride --add-source drop/nuget
+      working-directory: docfx-build
+      shell: pwsh
+      # End of Temporary solution
+
+    #- name: Install DocFX
       # This installs the latest version of DocFX and may introduce breaking changes
       # run: dotnet tool update -g docfx
       # This installs a specific, tested version of DocFX.
-      run: dotnet tool update -g docfx --version 2.78.3
+      #run: dotnet tool update -g docfx --version 2.78.3
 
     - name: Build documentation
       run: ./build-all.bat
       working-directory: ${{ env.DOCS_PATH }}
 
     - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3.9.2
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ${{ env.DOCS_PATH }}/_site

--- a/.github/workflows/stride-docs-release-azure.yml
+++ b/.github/workflows/stride-docs-release-azure.yml
@@ -32,13 +32,13 @@ jobs:
 
     steps:
     - name: .NET SDK Setup
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
 
     # Checkout the Stride Docs repository from the branch that triggered the workflow
     - name: Checkout Stride Docs
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         path: ${{ env.DOCS_PATH }}
         lfs: true
@@ -52,7 +52,7 @@ jobs:
 
     # Checkout the Stride repository from the default branch
     - name: Checkout Stride (note the LFS)
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: stride3d/stride
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -61,12 +61,14 @@ jobs:
         ref: master
 
     # Temporary solution till the new docfx is available
-    - name: Checkout DocFX PR Branch
-      uses: actions/checkout@v5
+    - name: Checkout DocFX
+      uses: actions/checkout@v6
       with:
-        repository: filzrev/docfx
-        ref: feat-add-net10-support
+        repository: dotnet/docfx
+        # Tested commit
+        ref: 917cda864650279e0bbe50b852cb98601e5efa4d
         path: docfx-build
+        fetch-depth: 0
 
     - name: Restore npm dependencies
       run: npm install
@@ -86,7 +88,7 @@ jobs:
       working-directory: docfx-build
       shell: pwsh
       # End of Temporary solution
-      
+
     #- name: Install DocFX
       # This installs the latest version of DocFX and may introduce breaking changes
       # run: dotnet tool update -g docfx
@@ -101,7 +103,7 @@ jobs:
       run: 7z a -r DocFX-app.zip ./${{ env.DOCS_PATH }}/_site/*
 
     - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: DocFX-app
         path: DocFX-app.zip
@@ -124,7 +126,7 @@ jobs:
 
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: DocFX-app
 

--- a/.github/workflows/stride-docs-release-fast-track-azure.yml
+++ b/.github/workflows/stride-docs-release-fast-track-azure.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
     - name: .NET SDK Setup
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
 
     # Checkout the Stride Docs repository from the branch that triggered the workflow
     - name: Checkout Stride Docs
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         path: ${{ env.DOCS_PATH }}
         lfs: true
@@ -46,7 +46,7 @@ jobs:
 
     # Checkout the Stride repository from the default branch
     - name: Checkout Stride (note the LFS)
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: stride3d/stride
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -55,12 +55,14 @@ jobs:
         ref: master
 
     # Temporary solution till the new docfx is available
-    - name: Checkout DocFX PR Branch
-      uses: actions/checkout@v5
+    - name: Checkout DocFX
+      uses: actions/checkout@v6
       with:
-        repository: filzrev/docfx
-        ref: feat-add-net10-support
+        repository: dotnet/docfx
+        # Tested commit
+        ref: 917cda864650279e0bbe50b852cb98601e5efa4d
         path: docfx-build
+        fetch-depth: 0
 
     - name: Restore npm dependencies
       run: npm install

--- a/.github/workflows/stride-docs-staging-azure.yml
+++ b/.github/workflows/stride-docs-staging-azure.yml
@@ -29,13 +29,13 @@ jobs:
 
     steps:
     - name: .NET SDK Setup
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
 
     # Checkout the Stride Docs repository from the branch that triggered the workflow
     - name: Checkout Stride Docs
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         path: ${{ env.DOCS_PATH }}
         lfs: true
@@ -57,7 +57,7 @@ jobs:
 
     # Checkout the Stride repository from the default branch
     - name: Checkout Stride (note the LFS)
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: stride3d/stride
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -66,12 +66,14 @@ jobs:
         ref: master
 
     # Temporary solution till the new docfx is available
-    - name: Checkout DocFX PR Branch
-      uses: actions/checkout@v5
+    - name: Checkout DocFX
+      uses: actions/checkout@v6
       with:
-        repository: filzrev/docfx
-        ref: feat-add-net10-support
+        repository: dotnet/docfx
+        # Tested commit
+        ref: 917cda864650279e0bbe50b852cb98601e5efa4d
         path: docfx-build
+        fetch-depth: 0
 
     - name: Restore npm dependencies
       run: npm install
@@ -91,7 +93,7 @@ jobs:
       working-directory: docfx-build
       shell: pwsh
       # End of Temporary solution
-      
+
     #- name: Install DocFX
       # This installs the latest version of DocFX and may introduce breaking changes
       # run: dotnet tool update -g docfx
@@ -106,7 +108,7 @@ jobs:
       run: 7z a -r DocFX-app.zip ./${{ env.DOCS_PATH }}/_site/*
 
     - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: DocFX-app
         path: DocFX-app.zip
@@ -122,7 +124,7 @@ jobs:
 
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v6
+      uses: actions/download-artifact@v7
       with:
         name: DocFX-app
 

--- a/.github/workflows/stride-docs-staging-fast-track-azure.yml
+++ b/.github/workflows/stride-docs-staging-fast-track-azure.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
     - name: .NET SDK Setup
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 10.x
 
     # Checkout the Stride Docs repository from the branch that triggered the workflow
     - name: Checkout Stride Docs
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         path: ${{ env.DOCS_PATH }}
         lfs: true
@@ -43,7 +43,7 @@ jobs:
 
     # Checkout the Stride repository from the default branch
     - name: Checkout Stride (note the LFS)
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         repository: stride3d/stride
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -52,12 +52,14 @@ jobs:
         ref: master
 
     # Temporary solution till the new docfx is available
-    - name: Checkout DocFX PR Branch
-      uses: actions/checkout@v5
+    - name: Checkout DocFX
+      uses: actions/checkout@v6
       with:
-        repository: filzrev/docfx
-        ref: feat-add-net10-support
+        repository: dotnet/docfx
+        # Tested commit
+        ref: 917cda864650279e0bbe50b852cb98601e5efa4d
         path: docfx-build
+        fetch-depth: 0
 
     - name: Restore npm dependencies
       run: npm install

--- a/.github/workflows/stride-docs-test-build.yml
+++ b/.github/workflows/stride-docs-test-build.yml
@@ -96,7 +96,7 @@ jobs:
       run: 7z a -r DocFX-app.zip ./${{ env.DOCS_PATH }}/_site/*
 
     - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: DocFX-app
         path: DocFX-app.zip


### PR DESCRIPTION
ci: Update workflows and DocFX build process

- stride-docs-github.yml - Upgrade actions to latest major versions (setup-dotnet v5, checkout v6, upload-artifact v6, download-artifact v7, gh-pages v4)
- stride-docs-release-azure.yml - Same action upgrades and DocFX build changes
- stride-docs-release-fast-track-azure.yml - Same action upgrades and DocFX build changes
- stride-docs-staging-azure.yml - Same action upgrades and DocFX build changes
- stride-docs-staging-fast-track-azure.yml - Same action upgrades and DocFX build changes
- stride-docs-test-build.yml - Upgrade upload-artifact to v6
- Replace prebuilt DocFX install with build from official dotnet/docfx at commit 917cda8
- Build and install custom DocFX NuGet package (2.9-stride) from source for improved reliability and .NET 10 support
- Comment out previous dotnet tool update DocFX install steps
- Ensure consistent, tested DocFX version across all workflows

#### PR Classification
Workflow and build system update to improve reliability, compatibility, and maintainability.

#### PR Summary
This PR updates GitHub Actions workflows for Stride documentation to use newer action versions and a custom-built DocFX compatible with .NET 10. The DocFX installation process is streamlined and standardized across all workflow files.
- stride-docs-*.yml: Updated actions/setup-dotnet, actions/checkout, actions/upload-artifact, actions/download-artifact, and peaceiris/actions-gh-pages to latest major versions.
- stride-docs-*.yml: Replaced DocFX installation with a process that builds and installs a specific commit from the official dotnet/docfx repository.
- stride-docs-*.yml: Removed use of the filzrev/docfx fork and ensured npm dependencies for DocFX templates are built before installation.
- stride-docs-*.yml: Updated or commented out obsolete DocFX installation steps and related comments.
