### PR TITLE
Deploy latest documentation updates to staging

### DIFF
--- a/en/manual/stride-for-godot-developers/index.md
+++ b/en/manual/stride-for-godot-developers/index.md
@@ -2,7 +2,22 @@
 
 ## Editor
 
-The Stride editor is **Game Studio**.
+The Stride editor is **Game Studio**. This is the equivalent of the Godot Editor.
+
+### Godot
+
+Godot provides a built-in code editor that supports its own scripting language, GDScript, as well as C# and VisualScript. The Godot editor is more tightly integrated with the engine and is generally kept up-to-date with new features.
+
+In summary, while both Stride and Godot offer integrated code editors, Stride's editor is best considered a supplementary tool rather than a complete IDE. It is advised to use specialized IDEs for more complex development tasks in Stride. Godot's editor, on the other hand, is robust enough for full-scale development if you are using GDScript or C#.
+
+### Stride
+
+Stride comes with an integrated C# code editor within Game Studio. Although functional, this editor is not a high-priority feature and may not receive frequent updates. As such, it is generally recommended to use dedicated IDEs for code editing. Some popular choices include:
+
+- Visual Studio Code: Free, open-source and highly extensible.
+- Rider: Paid, but offers a robust set of features tailored for .NET development.
+- Visual Studio Community: Free for small teams and individual developers.
+- Visual Studio Professional and Enterprise: Paid versions with additional features and services.
 
 ![Godot layout](media/stride-vs-godot-godotlayout.webp)
 
@@ -17,27 +32,27 @@ For more information about Game Studio, see the [Game Studio](../game-studio/ind
 
 | Godot | Stride |
 |-------|--------|
-| Scene | Entity Tree |
+| Scene (`PackedScene`) | Prefab / scene asset |
 | Inspector | Property Grid |
 | FileSystem | Solution/Asset View |
-| Scene view | Scene Editor |
-| Node | Entity |
-| Node Script | SyncScript, AsyncScript, StartupScript |
-| Export | Serialize/DataMember |
-| GlobalClass | DataContract |
+| 2D/3D Viewport | Scene Editor |
+| Node | [`Entity`](xref:Stride.Engine.Entity) |
+| Script attached to Node | Script component ([`SyncScript`](xref:Stride.Engine.SyncScript), [`AsyncScript`](xref:Stride.Engine.AsyncScript), [`StartupScript`](xref:Stride.Engine.StartupScript)) |
+| `[Export]` | `[DataMember]` |
+| `[GlobalClass]` | `[DataContract]` on serializable classes (to expose custom types in the editor) |
 
 ## Folders and files
 
 - **Assets**
-  - In Godot you can store assets everywhere.
-  - In Stride Assets are in the Assets Folder
-- Stride and Godot use the Standard C# Solution Structure. Key difference here is that Stride uses the multi Project architecture which leads to the following Projects
+  - In Godot, you can store assets anywhere.
+  - In Stride, assets are stored in the `Assets` folder.
+- Stride and Godot use the standard C# solution structure. A key difference is that Stride uses a multi-project architecture with the following projects:
   - `MyPackage.Game` contains your source code.
-  - `MyPackage.Platform` contains additional code for the platforms your project supports. Game Studio creates folders for each platform (eg `MyPackage.Windows`, `MyPackage.Linux`, etc). These folders are usually small, and only contain the entry point of the program.
-  - And any other Subprojects. Stride will scan the Subprojects too like the main Project to get DataContract classes and features into the Editor/Game ( it doesn't matter if its in a subproject or not
-- **Bin:** contains the compiled binaries and data. Stride creates the folder when you build the project, with a subdirectory for each platform.
-- **obj:** contains cached files. Game Studio creates this folder when you build your project. To force a complete asset and code rebuild, delete this folder and build the project again.
-- **Resources:** is a suggested location for files such as images and audio files used by your assets, do not confuse them with Godot resources, these don't exist in Stride. Stride has in the Scene Folders (these can be used in any way) where you can put classes that would be normally Godot Resources
+  - `MyPackage.Platform` contains additional code for the platforms your project supports. Game Studio creates folders for each platform (for example, `MyPackage.Windows`, `MyPackage.Linux`, etc.). These folders are usually small and only contain the program entry point.
+  - Any additional subprojects. Stride scans subprojects the same way it scans the main project to find `DataContract` classes and features for the editor and game.
+- **Bin** contains the compiled binaries and data. Stride creates the folder when you build the project, with a subdirectory for each platform.
+- **obj** contains cached files. Game Studio creates this folder when you build your project. To force a complete asset and code rebuild, delete this folder and build the project again.
+- **Resources** is a suggested location for files such as images and audio used by your assets. Godot and Stride use different resource systems, so treat this as a project-organization folder rather than a Godot-style `Resource` type.
 
 ### Open the project directory from Game Studio
 
@@ -46,69 +61,169 @@ You can open the project directory from **Project > Show in explorer** in Game S
 ![Open project directory from Game Studio](../stride-for-unity-developers/media/stride-vs-unity-open-project-in-windows-explorer.png)
 
 ## Game settings
-Godot saves global settings in the [Project Settings](https://docs.godotengine.org/cs/stable/classes/class_projectsettings.html) .
+Godot saves global settings in [Project Settings](https://docs.godotengine.org/cs/stable/classes/class_projectsettings.html).
 
-~~The location is not known to me~~
 
-Stride saves global settings in a single asset, the Game Settings asset. You can configure:
+Stride saves global settings in a single asset, the **Game Settings** asset. You can configure:
 
-- The default scene
-- Rendering settings
-- Editor settings
-- Texture settings
-- Physics settings
-- Overrides
-- 
+* The **default scene**
+* **Rendering settings**
+* **Editor settings**
+* **Texture settings**
+* **Physics settings**
+* **Overrides**
+
 To use the Game Settings asset, in the **Asset View**, select **GameSettings** and view its properties in the **Property Grid**.
+
+![Game settings](../stride-for-unity-developers/media/game-settings.png)
 
 ## Scenes
 
-Set the default scene
-You can have multiple scenes in your project. Stride loads the default scene at runtime.
+Like Godot, in Stride you place all objects in a scene. Game Studio stores scenes as separate `.sdscene` assets in your project directory.
+
+### Set the default scene
+
+You can have multiple scenes in your project. The scene that loads as soon as your game starts is called the *Default Scene*.
 
 To set the default scene:
 
+1. In the **GameSettings** properties, next to **Default Scene**, click ![Hand icon](~/manual/game-studio/media/hand-icon.png) (**Select an asset**).
+
+    ![Set default scene](../stride-for-unity-developers/media/stride-vs-unity-game-settings-default-scene.png)
+
+    The **Select an asset** window opens.
+2. Select the default scene and click **OK**.
+
+For more information about scenes, see [Scenes](../game-studio/scenes.md).
+
+
 ## Entities vs Nodes
 
-### Directions
+In Godot, objects in the scene are called **Nodes** (organized in the **Scene Tree**). In Stride, they're called **entities**.
+
+![Entities in Stride](../stride-for-unity-developers/media/stride-vs-unity-entities.jpg)
+
+Like Nodes, entities are carriers for "behavior" and data. In Godot, this is typically done by using different node types (for example, `Node3D`, `Sprite2D`, `AudioStreamPlayer`) and attaching scripts. In Stride, this is done by adding **components** (transform components, model components, audio components, and so on). If you're used to working with Nodes in Godot, you should have no problem using entities in Game Studio.
+
+## Entity components
+
+In Stride, you add components to entities in the editor much like you attach child nodes or configure node properties in the Godot editor.
+
+To add a component to an entity in Game Studio:
+
+1. Select the entity you want to add the component to.
+2. In the **Property Grid** (on the right by default), click **Add component** and select the component from the drop-down list.
+
+    ![Add component](../stride-for-unity-developers/media/stride-vs-unity-add-component-to-entity.png)
+
+### Transform component
+
+Like `Node3D` / `Node2D` in Godot, each entity in Stride has a [Transform component](xref:Stride.Engine.TransformComponent) that sets its position, rotation, and scale in the world.
+
+![Transform component](../stride-for-unity-developers/media/stride-vs-unity-entity-transform-component.png)
+
+All entities are created with a Transform component by default.
+
+In Stride, Transform components contain a LocalMatrix and a WorldMatrix that are updated every Update frame. If you need to force an update sooner, you can use `TransformComponent.UpdateLocalMatrix()`, `Transform.UpdateWorldMatrix()`, or `Transform.UpdateLocalFromWorld()`, depending on how you need to update the matrix.
+
+#### Local Position/Rotation/Scale
+
+Stride uses position, rotation, and scale to refer to the local position, rotation, and scale.
+
+| Godot (typical 3D)         | Stride                       |
+|----------------------------|------------------------------|
+| `position`                 | `Transform.Position`         |
+| `quaternion` / `basis`     | `Transform.Rotation`         |
+| `rotation` / `rotation_degrees` | `Transform.RotationEulerXYZ` |
+| `scale`                    | `Transform.Scale`            |
+
+> [!TIP]
+> In Godot, `Node3D.rotation` is Euler angles in **radians**, and Godot also exposes convenience properties like `rotation_degrees`.
+
+
+#### World Position/Rotation/Scale
+
+In Godot, world-space transform values are typically accessed via `global_*` properties or `global_transform`. In comparison to Godot, many of the Transform component's properties related to its location in the world are accessed via Stride's [WorldMatrix](xref:Stride.Engine.TransformComponent.WorldMatrix).
+
+| Godot (4.x, Node3D)                                                                 | Stride                                                                                                 |
+|-------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| `global_position` (== `global_transform.origin`)                                    | `Transform.WorldMatrix.TranslationVector`                                                              |
+| `global_rotation` (Euler, radians)                                                  | Decompose from `Transform.WorldMatrix`                                                                 |
+| `global_scale`                                                                      | Decompose from `Transform.WorldMatrix`                                                                 |
+| `global_transform`                                                                  | `Transform.WorldMatrix`                                                                                |
+| `global_transform.basis` (rotation/scale/shear in global space)                     | Use direction vectors and decomposition on `Transform.WorldMatrix`                                     |
+| Decompose from `global_transform` / `global_transform.basis` (rotation/scale etc.)  | `Transform.WorldMatrix.DecomposeXYZ(out Vector3 rotation)`                                             |
+| Decompose translation/scale                                                         | `Transform.WorldMatrix.Decompose(out Vector3 scale, out Vector3 translation)`                          |
+| Decompose translation/rotation/scale                                                | `Transform.WorldMatrix.Decompose(out Vector3 scale, out Quaternion rotation, out Vector3 translation)` |
+
+> [!NOTE]
+> `WorldMatrix` is only updated after the entire Update loop runs, which means that you may be reading outdated data if that object's or its parent's position changed between the previous frame and now.
+> To ensure you're reading the latest position and rotation, you should force the matrix to update by calling `Transform.UpdateWorldMatrix()` before reading from it.
+
+
+#### Transform Directions
+
+In Godot, direction vectors are commonly derived from the transform basis (for example using `global_transform.basis`). In Stride, the `WorldMatrix` exposes direction vectors directly. Note that those are matrix properties, so setting one of those is not enough to properly rotate the matrix.
+
+| Godot (typical 3D)                              | Stride                           |
+|-------------------------------------------------|----------------------------------|
+| `-global_transform.basis.z` (forward in 3D)     | `Transform.WorldMatrix.Forward`  |
+| `global_transform.basis.z` (backward in 3D)     | `Transform.WorldMatrix.Backward` |
+| `global_transform.basis.x` (right)              | `Transform.WorldMatrix.Right`    |
+| `-global_transform.basis.x` (left)              | `Transform.WorldMatrix.Left`     |
+| `global_transform.basis.y` (up)                 | `Transform.WorldMatrix.Up`       |
+| `-global_transform.basis.y` (down)              | `Transform.WorldMatrix.Down`     |
+
+> [!NOTE]
+> See the note in [World Position/Rotation/Scale](#world-positionrotationscale)
 
 ## Assets
 
+Assets are imported and managed in the **Asset View**.
+
 ## Resources
 
-Stride doesn't have Resources like Godot has. In Stride you can add Folders to your Scene and add there Entities with your Data. Another approach would be to save your former Resources in a separate Prefab and load it into the scenes that need the Data.
+Godot uses dedicated `Resource` objects. Stride does not use the same resource-object model. In Stride, equivalent data is usually represented with assets, prefabs, and serializable classes (`[DataContract]` / `[DataMember]`) that you reference from entities and scripts.
 
-## Supported File Formats
+For deeper details, see [Godot Resource](https://docs.godotengine.org/en/stable/classes/class_resource.html) and [Godot PackedScene](https://docs.godotengine.org/en/stable/classes/class_packedscene.html).
+
+## Supported file formats
 
 Like Godot, Stride supports file formats including:
 
 | Asset type  | Supported formats                                           
 |---|---|
-| Models, animations, skeletons | .dae, .3ds, obj, .blend, .x, .md2, .md3, .dxf, .fbx
+| Models, animations, skeletons | .dae, .3ds, .obj, .blend, .x, .md2, .md3, .dxf, .fbx
 | Sprites, textures, skyboxes   | .dds, .jpg, .jpeg, .png, .gif, .bmp, .tga, .psd, .tif, .tiff
 | Audio  	                    | .wav, .mp3, .ogg, .aac, .aiff, .flac, .m4a, .wma, .mpc
 | Fonts                         | .ttf, .otf |
-|Video                          | .mp4
+| Video                         | .mp4
 
 For more information about assets, see [Assets](../game-studio/assets.md).
 
-## Prefab Inheritance
+## Prefab inheritance
 
-The equivalent of Godot's inherited Scene would be ArcheTypes. Archetypes are master assets that control the properties of assets you derive from them. Derived assets are useful when you want to create a "remixed" version of an asset. This is similar to prefabs.
+The equivalent of Godot's inherited scene is archetypes. Archetypes are master assets that control the properties of assets you derive from them. Derived assets are useful when you want to create a "remixed" version of an asset. This is similar to prefabs.
 
 For example, imagine we have three sphere entities that share a material asset named Metal. Now imagine we want to change the color of only one sphere, but keep its other properties the same. We could duplicate the material asset, change its color, and then apply the new asset to only one sphere. But if we later want to change a different property across all the spheres, we have to modify both assets. This is time-consuming and leaves room for mistakes.
 
 The better approach is to derive a new asset from the archetype. The derived asset inherits properties from the archetype and lets you override individual properties where you need them. For example, we can derive the sphere's material asset and override its color. Then, if we change the gloss of the archetype, the gloss of all three spheres changes.
 
+## Object lifetime
+
+In Godot, nodes are commonly removed with `queue_free()` / `free()`. In Stride, entities and components are removed from scenes/entities and then released by the .NET garbage collector when no longer referenced.
+
+This enables patterns such as removing an entity from one scene and adding it to another later, as long as references are preserved.
+
 ## Input
 
-In Stride you have the Option to get the Input through Key Strokes like in Godot or through Virtual Buttons, which is similar to Godot's Key Mapping
+In Stride, you can handle input through keystrokes, similar to Godot, or through virtual buttons, which is similar to Godot's input mapping.
 
 ```cs
 public override void Update()
 {
     // true for one frame in which the space bar was pressed
-    if(Input.IsKeyDown(Keys.Space))
+    if (Input.IsKeyDown(Keys.Space))
     {
         // Do something.
     }
@@ -125,9 +240,17 @@ public override void Update()
 }
 ```
 
+## Time
+
+| Godot | Stride |
+|---|---|
+| `delta` in `_Process(double delta)` | `Game.UpdateTime.Elapsed.TotalSeconds` |
+| `delta` in `_PhysicsProcess(double delta)` | `Game.UpdateTime.Elapsed.TotalSeconds` |
+| `Engine.time_scale` | `Game.UpdateTime.Factor` |
+
 ## Physics
 
-Both Stride and Godot offer comprehensive physics engines, but their approach to handling collisions and physics-based interactions differ. Below is a comparison of their features and functionalities.
+Both Stride and Godot offer comprehensive physics engines, but their approaches to handling collisions and physics-based interactions differ. Below is a comparison of their features and functionality.
 
 ### Stride
 
@@ -136,44 +259,25 @@ In Stride, there are three main types of colliders:
 - **Static Colliders:** Fixed in place and do not move, typically used for environment elements like walls or floors.
 - **Rigidbodies:** Dynamic colliders that are subject to physics simulations, such as gravity or force.
 - **Characters:** Special colliders designed to work with character controllers.
--
-To handle collisions in Stride, you can add methods to a delegate within the `Start()` method of your script. These methods will be triggered when a collision occurs. For a comprehensive tutorial on collision handling in Stride, you can refer to this [YouTube Stride tutorial - Collision triggers](https://www.youtube.com/watch?v=SIy3pfoXfoQ&ab_channel=Stride).
+
+In Stride, collision handling is done through physics components and script logic that handle collision events and triggers. For details, see [Physics](../physics/index.md), [Triggers](../physics/triggers.md), and [Raycasting](../physics/raycasting.md).
 
 ### Godot
 
 In Godot, you can use a signal-based system to react to collisions. Signals are emitted when specific events occur, such as two objects colliding, and you can connect these signals to custom methods to execute your own logic.
 
-## Game Studio Editor
-
-Both Stride and Godot offer integrated code editors, but their capabilities and recommended usage differ.
-
-### Stride
-
-Stride comes with an integrated C# code editor within Game Studio. Although functional, this editor is not a high-priority feature and may not receive frequent updates. As such, it is generally recommended to use dedicated IDEs for code editing. Some popular choices include:
-
-- Visual Studio Code: Free, open-source and highly extensible.
-- Rider: Paid, but offers a robust set of features tailored for .NET development.
-- Visual Studio Community: Free for small teams and individual developers.
-- Visual Studio Professional and Enterprise: Paid versions with additional features and services.
- 
-### Godot
-
-Godot provides a built-in code editor that supports its own scripting language, GDScript, as well as C# and VisualScript. The Godot editor is more tightly integrated with the engine and is generally kept up-to-date with new features.
-
-In summary, while both Stride and Godot offer integrated code editors, Stride's editor is best considered a supplementary tool rather than a complete IDE. It is advised to use specialized IDEs for more complex development tasks in Stride. Godot's editor, on the other hand, is robust enough for full-scale development if you are using GDScript or C#.
-
 ## Scripts
 
-### Different Approaches to Scripting
+### Different approaches to scripting
 
 In Stride, there are three types of scripts, offering a different paradigm compared to Godot. While Godot requires you to inherit from a specific class to create a node of that type, Stride allows you to extend entities by adding scripts and then searching for specific entities to interact with.
 
-### Extending Entities in Stride
+### Extending entities in Stride
 
 For example, instead of inheriting from `CharacterBody3D` in Godot, in Stride you would attach a `CharacterComponent` to an entity. Don't forget to also attach a collision shape to make it interactable. In your scripts, you can then search for these components to manipulate them.
 
 
-#### Stride Example
+#### Stride example
 
 ```csharp
 // Example of searching for a CharacterComponent in Stride
@@ -191,15 +295,15 @@ public class MyScript : SyncScript
 }
 ```
 
-### Delegation Over Inheritance
+### Delegation over inheritance
 
 This approach in Stride embodies the principle of "Delegation over Inheritance", providing you with greater flexibility when designing your game's architecture.
 
 ### StartupScript
 
-`StartupScript` in Stride has a `Start` method, which is equivalent to Godot's `_Ready` method. A `StartupScript` primarily focuses on initialization tasks and doesn't offer much functionality beyond that.
+`StartupScript.Start()` is closest to Godot's `_Ready()` in terms of initialization flow, but they are not lifecycle-identical in every engine detail. In Godot, `_Ready()` runs when a node enters the scene tree, and parent nodes typically become ready before their children. In Stride, `StartupScript.Start()` runs when the script is started after the scene or entity is initialized, and the exact parent-child start order might not match Godot's. In practice, use `StartupScript` for initialization and setup tasks.
 
-#### Stride Example
+#### Stride example
 ```csharp
 public class BasicMethods : StartupScript
 {
@@ -216,7 +320,9 @@ public class BasicMethods : StartupScript
 }
 ```
  
-#### Godot Example
+#### Godot example
+
+##### [C#](#tab/StartupScript-csharp)
 
 ```csharp
 public class BasicMethods : Node
@@ -236,6 +342,24 @@ public class BasicMethods : Node
 }
 ```
 
+##### [GDScript](#tab/StartupScript-gdscript)
+
+```csharp
+extends Node
+
+func _ready() -> void:
+    # Initialization code for the script
+    pass
+
+# Godot doesn't have a direct equivalent to Stride's Cancel,
+# but you could use _ExitTree for cleanup
+func _exit_tree() -> void:
+    # Cleanup code for the script
+    pass
+```
+
+---
+
 ### SyncScript
 
 Both Stride and Godot offer methods that are repeatedly called for game updates. In Stride, this method is called `Update()` and is part of the `SyncScript` class. In Godot, the equivalent is `_Process(double delta)`.
@@ -244,7 +368,7 @@ Both Stride and Godot offer methods that are repeatedly called for game updates.
 1. **Delta Time:** Stride's `Update()` does not include a delta time parameter. In contrast, Godot provides the time since the last frame as an argument (delta) in `_Process(double delta)`.
 2. **Access to Delta Time:** In Stride, you can still access the delta time through the Game property, `using Game.UpdateTime.Elapsed.TotalSeconds`.
 
-#### Stride Example
+#### Stride example
 
 
 ```csharp
@@ -262,7 +386,9 @@ public class BasicMethods : SyncScript
 }
 ```
 
-#### Godot Example
+#### Godot example
+
+##### [C#](#tab/SyncScript-csharp)
 
 ```csharp
 public class BasicMethods : Node
@@ -277,14 +403,31 @@ public class BasicMethods : Node
 
 ```
 
-### AsyncScripts
+##### [GDScript](#tab/SyncScript-gdscript)
+
+```csharp
+extends Node
+
+func _ready() -> void:
+    pass
+
+func _exit_tree() -> void:
+    pass
+
+func _process(delta: float) -> void:
+    # Perform actions based on delta
+    pass
+```
+
+---
+
+### AsyncScript
 
 Both Stride and Godot provide ways to run code asynchronously, but they use different approaches.
 
-#### Stride Example
+#### Stride example
 
 Stride offers a specialized `AsyncScript` class that allows you to execute code asynchronously using C#'s `async`/`await` syntax. The `Execute()` method can be awaited, allowing your code to run without blocking the main game loop.
-
 
 ```csharp
 public class BasicMethods : AsyncScript
@@ -314,9 +457,11 @@ public class BasicMethods : AsyncScript
 
 ```
 
-#### Godot Example
+#### Godot example
 
 Godot doesn't offer a dedicated `AsyncScript` class like Stride. However, you can still write asynchronous code in C# using the standard `async`/`await` syntax.
+
+##### [C#](#tab/AsyncScript-csharp)
 
 ```csharp
 public class BasicMethods : Node
@@ -335,6 +480,24 @@ public class BasicMethods : Node
 }
 ```
 
+##### [GDScript](#tab/AsyncScript-gdscript)
+
+```csharp
+extends Node
+
+func _ready() -> void:
+    await get_tree().create_timer(1.0).timeout
+    # Execute code after 1-second timer elapses
+    pass
+
+# Godot doesn't have a direct equivalent to Stride's Cancel method
+func _exit_tree() -> void:
+    # Cleanup code for the script
+    pass
+```
+
+---
+
 In summary, both Stride and Godot offer mechanisms for running code asynchronously, but they achieve this in different ways. Stride provides a built-in `AsyncScript` class, whereas Godot allows for asynchronous code through standard C# mechanisms.
 
 ## Script components
@@ -345,20 +508,20 @@ In both Stride and Godot, scripts are used to define behavior and logic for game
 
 #### Stride
 
-To create a script, click **Add asset** button and select **Scripts**.
+To create a script, click the **Add asset** button and select **Scripts**.
 
 ![Create script in Stride](../stride-for-unity-developers/media/stride-vs-unity-create-script.png)
 
 Stride has a [SyncScript](xref:Stride.Engine.SyncScript) class that comes with methods such as:
 
-* [Start()](xref:Stride.Engine.StartupScript.Start) is called when the script is loaded.
-* [Update()](xref:Stride.Engine.SyncScript.Update) is called every frame.
+* [`SyncScript.Start()`](xref:Stride.Engine.StartupScript.Start) is called when the script is loaded.
+* [`SyncScript.Update()`](xref:Stride.Engine.SyncScript.Update) is called every update.
 
 
-If you need asynchronous or startup-specific logic, you can use:
+If you want your script to be a startup or asynchronous, use the corresponding script types:
 
-* [StartupScript](xref:Stride.Engine.StartupScript): this script has a single [Start()](xref:Stride.Engine.StartupScript.Start) method. It initializes the scene and its content at startup.
-* [AsyncScript](xref:Stride.Engine.AsyncScript): an asynchronous script with a single method [Execute()](xref:Stride.Engine.AsyncScript.Execute) and you can use `async`/`await` inside that method. Asynchronous scripts aren't loaded one by one like synchronous scripts. Instead, they're all loaded in parallel.
+* [`StartupScript`](xref:Stride.Engine.StartupScript): this script has a single [`StartupScript.Start()`](xref:Stride.Engine.StartupScript.Start) method. It initializes the scene and its content at startup.
+* [`AsyncScript`](xref:Stride.Engine.AsyncScript): an asynchronous script with a single method [`AsyncScript.Execute()`](xref:Stride.Engine.AsyncScript.Execute) and you can use async/await inside that method. Asynchronous scripts aren't loaded one by one like synchronous scripts. Instead, they're all loaded in parallel.
 
 #### Godot
 
@@ -371,7 +534,7 @@ In Godot, you use methods like `_Ready()` for initialization and `_Process(delta
 
 #### Stride
 
-After creating or editing a script, you must manually reload the assemblies by clicking **Reload assemblies** in the Game Studio toolbar.
+After you create a script, you may have to reload the assemblies manually. To do this, click **Reload assemblies** in the Game Studio toolbar.
 
 ![Reload assemblies](../platforms/media/reload-assemblies.png)
 
@@ -399,7 +562,25 @@ In Stride, scripts are listed alphabetically along with other components. In God
 
 For more information about adding scripts in Stride, see [Use a script](../scripts/use-a-script.md).
 
-## Instantiate Prefabs
+## Instantiate prefabs
+
+In Godot, the common equivalent is instantiating a `PackedScene`.
+
+##### [C#](#tab/prefabs-csharp)
+
+```csharp
+var node = packedScene.Instantiate<Node3D>();
+AddChild(node);
+```
+
+##### [GDScript](#tab/prefabs-gdscript)
+
+```csharp
+var node = packedScene.instantiate()
+add_child(node)
+```
+
+---
 
 In Stride, you can instantiate entities using prefabs like so:
 
@@ -430,7 +611,7 @@ public override void Start()
 
 ### Godot
 
-In Godot, you need to inherit from an engine class for it to be visible in the editor. Additionally, only types known to the Godot engine can be exported.
+In Godot C#, inspector-exposed members typically use `[Export]`, and the script is commonly attached to a node type. Export support is tied to types the engine can serialize.
 
 ### Stride
 
@@ -462,7 +643,7 @@ public class MyClass
 }
 ```
 
-#### Excluding Members
+#### Excluding members
 
 To exclude a member from serialization, use the `[DataMemberIgnore]` attribute.
 
@@ -475,21 +656,21 @@ public class MyClass
 }
 ```
 
-#### Collections and Dictionaries
+#### Collections and dictionaries
 
 Stride supports `ICollection` and `IDictionary` classes for serialization. Note that only primitives and enums can be used as keys in dictionaries.
 
-In Godot you have to Export Godot Collections to be visible in the Editor.
+In Godot, you need to export Godot collections for them to be visible in the editor.
 
-#### Nested Serialization
+#### Nested serialization
 
 You can serialize any class marked with `[DataContract]` into the editor, including abstract classes or interfaces. The **Stride Editor** will search for types that match the interfaces or abstract classes, making them eligible for serialization.
 
 ## Log output
 
-In Godot you can GD.Print your message. //TODO What does it mean?
+In Godot, you can print a message with `GD.Print`.
 
-To view the log output, go to the **Game Studio** toolbar and click on **View**, then enable the **Output** option.
+To view the log output, go to the **Game Studio** toolbar and click **View**, then enable the **Output** option.
 
 ![Enable output](../stride-for-unity-developers/media/enable-output.png)
 
@@ -500,14 +681,25 @@ Once enabled, the **Output** tab will appear, typically located at the bottom of
 
 ### Print debug messages
 
-To print to the Visual Studio output, use:
+Logging from a ScriptComponent:
+
+```cs
+public override void Start()
+{
+    // Enables logging. It will also spawn a console window if no debuggers are attached.
+    // The argument dictates the kinds of message that will be filtered out, in this case, anything with less priority than warning won't show up
+    Log.ActivateLog(LogMessageType.Warning);
+    // Log this message to your console or IDE output window
+    Log.Warning("hello");
+}
+```
 
 ```cs
 System.Diagnostics.Debug.WriteLine("hello");
 ```
 
->[!Note]
-> To print debug messages, you have to run the game from Visual Studio, not Game Studio. There's no way to print to the Game Studio output window.
+> [!NOTE]
+> To print debug messages, you have to run the game from your IDE, not Game Studio. Running games cannot print to the Game Studio output window.
 
 
 ## See also

--- a/en/manual/stride-for-unity-developers/index.md
+++ b/en/manual/stride-for-unity-developers/index.md
@@ -34,27 +34,19 @@ Unity® and Stride use mostly common terms, with a few differences:
 Like Unity®, Stride projects are stored in a directory that contains:
 
 * The project `.sln` solution file, which you can open with Game Studio or any IDE such as Visual Studio
+* A **MyGame.Game** folder with project source files, dependencies, resources, configurations, and binaries 
 
-* A **MyGame.Game** folder with project source files, dependencies, resources, configurations, and binaries
-
-  ![Package folder structure](../files-and-folders/media/folder-structure.png)
-
+![Package folder structure](../files-and-folders/media/folder-structure.png)
 * **Assets** contains asset configuration files.
-
 * **Bin** contains the compiled binaries and data. Stride creates the folder when you build the project, with a subdirectory for each platform.
-
 * **MyPackage.Game** contains your source code.
-
   * **MyPackage.Platform** contains additional code for the platforms your project supports. Game Studio creates folders for each platform (e.g. *MyPackage.Windows*, *MyPackage.Linux*, etc.). These folders are usually small and only contain the entry point of the program.
-
 * **obj** contains cached files. Game Studio creates this folder when you build your project. To force a complete asset and code rebuild, delete this folder and build the project again.
-
 * **Resources** is the recommended location for storing source files for your project, such as textures, models, and audio files.
 
 Stride and Unity® differ in the following ways:
 
 * Stride doesn't automatically copy resource files to your project folder when you import them into assets. You have to do this yourself. We recommend you save them in the **Resources** folder.
-
 * Stride doesn't require resource files and asset files to be in the same folder. You can save resource files in the Assets folder if you want, but instead, we recommend you save them in the **Resources** folder. This makes sharing your project via version control easier.
 
 For more information about project structure in Stride, including advice about how to organize and share your files, see the [Project structure](../files-and-folders/project-structure.md) page.
@@ -84,7 +76,7 @@ To use the Game Settings asset, in the **Asset View**, select **GameSettings** a
 
 ## Scenes
 
-Like Unity®, in Stride, you place all objects in a scene. Game Studio stores scenes as separate ``.sdscene`` assets in your project directory.
+Like Unity®, in Stride, you place all objects in a scene. Game Studio stores scenes as separate `.sdscene` assets in your project directory.
 
 ### Set the default scene
 
@@ -97,7 +89,6 @@ To set the default scene:
     ![Set default scene](media/stride-vs-unity-game-settings-default-scene.png)
 
     The **Select an asset** window opens.
-
 2. Select the default scene and click **OK**.
 
 For more information about scenes, see [Scenes](../game-studio/scenes.md).
@@ -129,7 +120,7 @@ Like GameObjects in Unity®, each entity in Stride has a [Transform component](x
 
 All entities are created with a Transform component by default.
 
-In Stride, Transform components contain a LocalMatrix and a WorldMatrix that are updated in every Update frame. If you need to force an update sooner than that you can use `TranformComponent.UpdateLocalMatrix()`, `Transform.UpdateWorldMatrix()`, or `Transform.UpdateLocalFromWorld()` to do so, depending on how you need to update the matrix.
+In Stride, Transform components contain a LocalMatrix and a WorldMatrix that are updated every Update frame. If you need to force an update sooner than that you can use `TransformComponent.UpdateLocalMatrix()`, `Transform.UpdateWorldMatrix()`, or `Transform.UpdateLocalFromWorld()` to do so, depending on how you need to update the matrix.
 
 #### Local Position/Rotation/Scale
 
@@ -155,9 +146,8 @@ In comparison to Unity, many of the Transform component's properties related to 
 | `transform.scale` and `transform.position`                        | `Transform.WorldMatrix.Decompose(out Vector3 scale, out Vector3 translation)`                          |
 | `transform.scale`, `transform.rotation`, and `transform.position` | `Transform.WorldMatrix.Decompose(out Vector3 scale, out Quaternion rotation, out Vector3 translation)` |
 
->[!Note]
-> `WorldMatrix` is only updated after the entire Update loop runs, which means that you may be reading outdated data if that object's or its parent's position changed between the previous frame and now.
-To ensure you're reading the latest position and rotation, you should force the matrix to update by calling `Transform.UpdateWorldMatrix()` before reading from it.
+> [!NOTE]
+> `WorldMatrix` is only updated after the entire Update loop runs, which means that you may be reading outdated data if that object's or its parent's position changed between the previous frame and now. To ensure you're reading the latest position and rotation, you should force the matrix to update by calling `Transform.UpdateWorldMatrix()` before reading from it.
 
 #### Transform Directions
 
@@ -173,8 +163,8 @@ Note that those are matrix properties, so setting one of those is not enough to 
 | `transform.up`           | `Transform.WorldMatrix.Up`       |
 | `transform.up * -1`      | `Transform.WorldMatrix.Down`     |
 
->[!Note]
-> See note in [World Position/Rotation/Scale](#world-positionrotationscale)
+> [!NOTE]
+> See the note in [World Position/Rotation/Scale](#world-positionrotationscale)
 
 ## Assets
 
@@ -197,16 +187,17 @@ To open the dedicated editor for these types of assets:
 
 * double-click the asset, or
 * right-click the asset and select Edit asset, or
-* select the asset and type Ctrl + Enter
+* select the asset and press Ctrl + Enter
 
 The editor opens in a new tab. You can arrange the tabs how you like, or float them as separate windows, just like tabs in web browsers.
 
 ![Dedicated Stride editors](media/stride-vs-unity-different-editors.png)
 
->[!Note]
->When you modify resource files outside Game Studio, the corresponding assets update automatically in Game Studio.
+> [!NOTE]
+> When you modify resource files outside Game Studio, the corresponding assets update automatically in Game Studio.
  
-### Scriptable Objects
+### Scriptable objects
+
 See the [Custom Assets](../scripts/custom-assets.md) page.
 
 ### Import assets
@@ -217,8 +208,8 @@ As soon as you add an asset to your project, you can edit its properties in the 
 
 ![Add asset](media/stride-vs-unity-add-asset.png)
 
->[!Note]
-> Unlike Unity®, Stride doesn't automatically copy resource files to the project directory when you import them to projects.
+> [!NOTE]
+> Unlike Unity®, Stride doesn't automatically copy resource files to the project directory when you import them into projects.
 
 ### Supported file formats
 
@@ -266,7 +257,7 @@ Archetype
 
 For more information about archetypes, see [Archetypes](../game-studio/archetypes.md).
 
-## Object Life Time
+## Object lifetime
 
 Entities and components are not destroyed in Stride, they are removed from the scene they exist in and then freed by the [Garbage Collector](https://learn.microsoft.com/en-us/dotnet/standard/garbage-collection/).
 
@@ -278,7 +269,7 @@ Components can be removed from an entity and added onto another without losing i
 
 Stride supports a variety of inputs. The code samples below demonstrate the difference in input code between Stride and Unity®.
 
-For more information about Input in Stride, see [Input](../input/index.md).
+For more information about input in Stride, see [Input](../input/index.md).
 
 #### Unity®
 
@@ -529,7 +520,7 @@ Alternatively, right-click the script in the **Asset View** and click **Open ass
 
 ### Event functions (Start, Update, Execute, etc)
 
-In Unity®, you work with MonoBehaviours with Start(), Update(), and other methods.
+In Unity®, you work with MonoBehaviours using Start(), Update(), and other methods.
 
 Instead of MonoBehaviours, Stride has three types of scripts: SyncScript, AsyncScript, and StartupScript. For more information, see [Types of script](../scripts/types-of-script.md).
 
@@ -607,16 +598,14 @@ To create a script, click the **Add asset** button and select **Scripts**.
 
 In Unity®, when you create a [`MonoBehaviour`](https://docs.unity3d.com/ScriptReference/MonoBehaviour.html) script, it has two base functions: [`MonoBehaviour.Start()`](https://docs.unity3d.com/ScriptReference/MonoBehaviour.Start.html) and [`MonoBehaviour.Update()`](https://docs.unity3d.com/ScriptReference/MonoBehaviour.Update.html). Stride has a [`SyncScript`](xref:Stride.Engine.SyncScript) that works similarly. Like [`MonoBehaviour`](https://docs.unity3d.com/ScriptReference/MonoBehaviour.html), [`SyncScript`](xref:Stride.Engine.SyncScript) has two methods:
 
-* [`SyncScript.Start()`](xref:Stride.Engine.StartupScript.Start) is called when it the script is loaded.
-
+* [`SyncScript.Start()`](xref:Stride.Engine.StartupScript.Start) is called when the script is loaded.
 * [`SyncScript.Update()`](xref:Stride.Engine.SyncScript.Update) is called every update.
 
-Unlike [`MonoBehaviour`](https://docs.unity3d.com/ScriptReference/MonoBehaviour.html), implementating the [`SyncScript.Update()`](xref:Stride.Engine.SyncScript.Update) method is not optional, and as such, must be implemented in every [`SyncScript`](xref:Stride.Engine.SyncScript).
+Unlike [`MonoBehaviour`](https://docs.unity3d.com/ScriptReference/MonoBehaviour.html), implementing the [`SyncScript.Update()`](xref:Stride.Engine.SyncScript.Update) method is not optional, and as such, must be implemented in every [`SyncScript`](xref:Stride.Engine.SyncScript).
 
 If you want your script to be a startup or asynchronous, use the corresponding script types:
 
 * [`StartupScript`](xref:Stride.Engine.StartupScript): this script has a single [`StartupScript.Start()`](xref:Stride.Engine.StartupScript.Start) method. It initializes the scene and its content at startup.
-
 * [`AsyncScript`](xref:Stride.Engine.AsyncScript): an asynchronous script with a single method [`AsyncScript.Execute()`](xref:Stride.Engine.AsyncScript.Execute) and you can use async/await inside that method. Asynchronous scripts aren't loaded one by one like synchronous scripts. Instead, they're all loaded in parallel.
 
 ### Reload assemblies
@@ -750,7 +739,7 @@ Light lightComponent = GetComponent<Light>();
 LightComponent lightComponent = Entity.Get<LightComponent>();
 ```
 
-### Access GameObject/entity  from component
+### Access GameObject/entity from component
 
 #### Unity®
 
@@ -766,11 +755,11 @@ Entity componentEntity = lightComponent.Entity;
 
 ## Log output
 
-To see the output, in the Game Studio toolbar, under **View**, enable **Output**.
+To view the log output, go to the **Game Studio** toolbar and click **View**, then enable the **Output** option.
 
 ![Enable output](media/enable-output.png)
 
-Game Studio displays in the **Output** tab (at the bottom of Game Studio by default).
+Once enabled, the **Output** tab will appear, typically located at the bottom of the **Game Studio** interface.
 
 ![Output tab](media/output-tab.png)
 
@@ -793,8 +782,8 @@ public override void Start()
 System.Diagnostics.Debug.WriteLine("hello");
 ```
 
->[!Note]
->To print debug messages, you have to run the game from your IDE, not Game Studio. Running games cannot print to the Game Studio output window.
+> [!NOTE]
+> To print debug messages, you have to run the game from your IDE, not Game Studio. Running games cannot print to the Game Studio output window.
 
 ## Attributes
 
@@ -807,8 +796,8 @@ System.Diagnostics.Debug.WriteLine("hello");
 | `[Header("My Header")]`   | `[Display(category: "My Header")]`  |
 | `[Tooltip("My tooltip")]` | `/// <userdoc>My tooltip</userdoc>` |
 
->[!Note]
->You cannot serialize `private` fields in Stride, if you want to set a field in editor but prevent other scripts from writing to that field, you should use a [init property](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/init)
+> [!NOTE]
+> You cannot serialize `private` fields in Stride, if you want to set a field in the editor but prevent other scripts from writing to that field, you should use an [init property](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/init)
 
 ```cs
 public float MyProperty { get; init; }

--- a/en/manual/toc.yml
+++ b/en/manual/toc.yml
@@ -7,8 +7,8 @@ items:
     href: requirements/index.md
   - name: Stride for Unity® developers
     href: stride-for-unity-developers/index.md
-  # - name: Stride for Godot developers
-  #   href: stride-for-godot-developers/index.md
+  - name: Stride for Godot developers
+    href: stride-for-godot-developers/index.md
   - name: Stride Launcher
     href: stride-launcher/index.md
 


### PR DESCRIPTION
* fix: Minor spacing updates

* fix: Consistency updates

* fix: Grammar corrections

* fix: Grammar consistency updates

* docs: Expand Stride for Godot developers documentation

- stride-for-godot-developers/index.md - Significantly expand and clarify documentation for Godot users
- stride-for-godot-developers/index.md - Improve terminology mapping, including scenes, prefabs, scripts, and serialization attributes
- stride-for-godot-developers/index.md - Clarify folder and resource management differences between Godot and Stride
- stride-for-godot-developers/index.md - Update transform/rotation/scale comparison tables with world matrix decomposition
- stride-for-godot-developers/index.md - Add sections on object lifetime and time management
- stride-for-godot-developers/index.md - Reference Stride physics documentation and clarify collision handling
- stride-for-godot-developers/index.md - Expand StartupScript and initialization flow comparison with Godot's _Ready()
- stride-for-godot-developers/index.md - Clarify assembly reload process and prefab instantiation comparison
- stride-for-godot-developers/index.md - Explain serialization and inspector exposure differences
- toc.yml - Add Stride for Godot developers page to navigation

* docs: Add Godot C# and GDScript examples to docs

- index.md - Add Godot C# and GDScript code samples for script lifecycle, update, async, and prefab instantiation concepts
- index.md - Organize examples with tabbed headers for C# and GDScript
- index.md - Add section dividers for clarity
- index.md - Clarify differences between Stride and Godot scripting approaches