### PR TITLE
Update Stride Shader Tools extension links to new publisher

### DIFF
--- a/en/manual/graphics/effects-and-shaders/custom-shaders.md
+++ b/en/manual/graphics/effects-and-shaders/custom-shaders.md
@@ -71,7 +71,7 @@ For shader-focused development with enhanced IntelliSense and inheritance visual
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/) or [VSCodium](https://vscodium.com/)
 2. Install the **Stride Shader Tools** extension:
-   - [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=tebjan.sdsl)
+   - [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=stride.sdsl)
    - [OpenVSX](https://open-vsx.org/extension/tebjan/sdsl) (for VSCodium and other alternatives)
 3. Create your `.sdsl` file in your project's **Assets** folder (or a subfolder within Assets)
 

--- a/en/manual/graphics/effects-and-shaders/shader-development-vscode.md
+++ b/en/manual/graphics/effects-and-shaders/shader-development-vscode.md
@@ -32,7 +32,7 @@ The VS Code extension provides:
 1. Open Visual Studio Code
 2. Install the **Stride Shader Tools** extension:
    - Open Extensions view (Ctrl+Shift+X) and search for **"Stride Shader Tools"**
-   - Or install directly from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=tebjan.sdsl) or [OpenVSX](https://open-vsx.org/extension/tebjan/sdsl) (for VSCodium and alternatives)
+   - Or install directly from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=stride.sdsl) or [OpenVSX](https://open-vsx.org/extension/tebjan/sdsl) (for VSCodium and alternatives)
 
 ### Configuration
 


### PR DESCRIPTION
## Summary
- Update VS Code Marketplace and OpenVSX links for the Stride Shader Tools extension
- Publisher changed from `tebjan` to `stride`
- Extension ID: `stride.sdsl` (was `tebjan.sdsl`)

Updates links in:
- `custom-shaders.md` 
- `shader-development-vscode.md`

The previous publisher was accidentally deleted and could not be restored by Microsoft. The extension has been re-published under the `stride` publisher.