### PR TITLE
Fixed broken API links

### DIFF
--- a/en/manual/scripts/types-of-script/async-script.md
+++ b/en/manual/scripts/types-of-script/async-script.md
@@ -66,7 +66,7 @@ public class Example : AsyncScript
 
 ## Executing tasks in parallel
 
-Sometimes it's useful to execute two async tasks in the same script. This can be achieved using [`Script.AddTask()`](xref:Stride.Engine.Processors.ScriptSystem.AddTask).
+Sometimes it's useful to execute two async tasks in the same script. This can be achieved using [`Script.AddTask()`](xref:Stride.Engine.Processors.ScriptSystem.AddTask*).
 
 ```csharp
 public class Example : AsyncScript

--- a/en/manual/stride-for-godot-developers/index.md
+++ b/en/manual/stride-for-godot-developers/index.md
@@ -141,7 +141,7 @@ Stride uses position, rotation, and scale to refer to the local position, rotati
 > [!TIP]
 > In Godot, `Node3D.rotation` is Euler angles in **radians**, and Godot also exposes convenience properties like `rotation_degrees`.
 > 
-> In order to get and set rotation using degrees use the utility methods [`MathUtil.DegreesToRadians`](xref:Stride.Core.Mathematics.MathUtil.DegreesToRadians) and [`MathUtil.RadiansToDegrees`](xref:Stride.Core.Mathematics.MathUtil.RadiansToDegrees) with `Transform.RotationEulerXYZ`.
+> In order to get and set rotation using degrees use the utility methods [`MathUtil.DegreesToRadians`](xref:Stride.Core.Mathematics.MathUtil.DegreesToRadians*) and [`MathUtil.RadiansToDegrees`](xref:Stride.Core.Mathematics.MathUtil.RadiansToDegrees*) with `Transform.RotationEulerXYZ`.
 
 
 #### World Position/Rotation/Scale


### PR DESCRIPTION
There were broken links on the godot page and the new types of script ones. That's mostly my fault, I haven't tested if they work because you can't generate the api on linux.