### PR TITLE
feat: add render order property to "Add a UI to a scene" documentation

### DIFF
--- a/en/manual/ui/add-a-ui-to-a-scene.md
+++ b/en/manual/ui/add-a-ui-to-a-scene.md
@@ -85,6 +85,7 @@ public void InitializeUI()
 | Snap text          | If selected, the UI text is snapped to the closest pixel
 | Fixed size         | Gets or sets the value indicating whether the UI should always be a fixed size on screen (eg a component with a height of 1 will use 0.1 of the screen). **Note:** This feature doesn't work in the current version of Stride
 | Render group       | The [render group](../graphics/graphics-compositor/render-groups-and-masks.md) the UI uses
+| Render order | Controls draw order when multiple UI components overlap. Lower values render first (behind), higher values render on top. Default is 0.
 
 ## UI scripts
 


### PR DESCRIPTION
Add `Render order` property to the UIComponent properties table on the "Add a UI to a scene" page.

This documents the new property introduced in https://github.com/stride3d/stride/pull/3104.