### PR TITLE
feat: Added syntax highlighting for gdscript

### DIFF
--- a/en/manual/stride-for-godot-developers/index.md
+++ b/en/manual/stride-for-godot-developers/index.md
@@ -325,7 +325,7 @@ public class BasicMethods : StartupScript
  
 #### Godot example
 
-##### [C#](#tab/StartupScript-csharp)
+##### [C#](#tab/csharp)
 
 ```csharp
 public class BasicMethods : Node
@@ -345,9 +345,9 @@ public class BasicMethods : Node
 }
 ```
 
-##### [GDScript](#tab/StartupScript-gdscript)
+##### [GDScript](#tab/gdscript)
 
-```csharp
+```gdscript
 extends Node
 
 func _ready() -> void:
@@ -391,7 +391,7 @@ public class BasicMethods : SyncScript
 
 #### Godot example
 
-##### [C#](#tab/SyncScript-csharp)
+##### [C#](#tab/csharp)
 
 ```csharp
 public class BasicMethods : Node
@@ -406,9 +406,9 @@ public class BasicMethods : Node
 
 ```
 
-##### [GDScript](#tab/SyncScript-gdscript)
+##### [GDScript](#tab/gdscript)
 
-```csharp
+```gdscript
 extends Node
 
 func _ready() -> void:
@@ -464,7 +464,7 @@ public class BasicMethods : AsyncScript
 
 Godot doesn't offer a dedicated `AsyncScript` class like Stride. However, you can still write asynchronous code in C# using the standard `async`/`await` syntax.
 
-##### [C#](#tab/AsyncScript-csharp)
+##### [C#](#tab/csharp)
 
 ```csharp
 public class BasicMethods : Node
@@ -483,9 +483,9 @@ public class BasicMethods : Node
 }
 ```
 
-##### [GDScript](#tab/AsyncScript-gdscript)
+##### [GDScript](#tab/gdscript)
 
-```csharp
+```gdscript
 extends Node
 
 func _ready() -> void:
@@ -569,16 +569,16 @@ For more information about adding scripts in Stride, see [Use a script](../scrip
 
 In Godot, the common equivalent is instantiating a `PackedScene`.
 
-##### [C#](#tab/prefabs-csharp)
+##### [C#](#tab/csharp)
 
 ```csharp
 var node = packedScene.Instantiate<Node3D>();
 AddChild(node);
 ```
 
-##### [GDScript](#tab/prefabs-gdscript)
+##### [GDScript](#tab/gdscript)
 
-```csharp
+```gdscript
 var node = packedScene.instantiate()
 add_child(node)
 ```

--- a/en/template/public/highlight/gdscript.js
+++ b/en/template/public/highlight/gdscript.js
@@ -1,0 +1,28 @@
+export default function(e) {
+  return {
+    aliases: ["godot", "gdscript"],
+    keywords: {
+      keyword:
+        "and in not or self void as assert breakpoint class class_name extends is func setget signal tool yield const enum export onready static var break continue if elif else for pass return match while remote sync master puppet remotesync mastersync puppetsync await",
+      built_in:
+        "Color8 ColorN abs acos asin atan atan2 bytes2var cartesian2polar ceil char clamp convert cos cosh db2linear decimals dectime deg2rad dict2inst ease exp floor fmod fposmod funcref get_stack hash inst2dict instance_from_id inverse_lerp is_equal_approx is_inf is_instance_valid is_nan is_zero_approx len lerp lerp_angle linear2db load log max min move_toward nearest_po2 ord parse_json polar2cartesian posmod pow preload print_stack push_error push_warning rad2deg rand_range rand_seed randf randi randomize range_lerp round seed sign sin sinh smoothstep sqrt step_decimals stepify str str2var tan tanh to_json type_exists typeof validate_json var2bytes var2str weakref wrapf wrapi bool int float String NodePath Vector2 Rect2 Transform2D Vector3 Rect3 Plane Quat Basis Transform Color RID Object NodePath Dictionary Array PoolByteArray PoolIntArray PoolRealArray PoolStringArray PoolVector2Array PoolVector3Array PoolColorArray",
+      literal: "true false null",
+    },
+    contains: [
+      e.NUMBER_MODE,
+      e.HASH_COMMENT_MODE,
+      { className: "comment", begin: /"""/, end: /"""/ },
+      e.QUOTE_STRING_MODE,
+      {
+        variants: [
+          { className: "function", beginKeywords: "func" },
+          { className: "class", beginKeywords: "class" },
+        ],
+        end: /\(/,
+        contains: [
+          e.UNDERSCORE_TITLE_MODE,
+        ],
+      },
+    ],
+  };
+}

--- a/en/template/public/main.js
+++ b/en/template/public/main.js
@@ -1,3 +1,5 @@
+import gdscript from './highlight/gdscript.js'
+
 const app = {
     languageDropdownCreated: false,
     iconLinks: [
@@ -240,6 +242,9 @@ const app = {
         this.waitForNavbarAndAddLanguageNavigation();
         this.addVersionNavigation();
         this.loadVersions();
+    },
+    configureHljs: function (hljs) {
+        hljs.registerLanguage('gdscript', gdscript);
     }
 };
 


### PR DESCRIPTION
This PR adds syntax highlighting for gdscript codeblocks, which are used on the `Stride for Godot developers` page. It also makes the tabs of that page synchronized, so that when a user switches to the gdscript tab in one place, it changes in others as well.

https://github.com/stride3d/stride-docs/issues/483