### PR TITLE
Improve “Released Games” section UI with header and screenshots

### DIFF
--- a/en/community-resources/games-and-demos.md
+++ b/en/community-resources/games-and-demos.md
@@ -2,11 +2,53 @@
 
 ## Released Games
 
-- [Distant Worlds 2](https://store.steampowered.com/app/1531540/Distant_Worlds_2/) - Vast, pausable real-time 4X space strategy game
-- [FPS Infinite](https://store.steampowered.com/app/1256380/FPS_Infinite/) - Procedural FPS with VR support
-- [Snaaker Friends](https://store.steampowered.com/app/1443760/Snaaker__Friends/) - Multiplayer Snake-inspired game
-- [Children of the Galaxy](https://www.emptykeys.com/games/children-of-the-galaxy/) - Turn-based strategy game
-- [Virtual Desktop](https://www.vrdesktop.net/) - VR desktop streaming app powered by Stride
+<div style="display: flex; flex-direction: column; gap: 15px;">
+    <div style="display: flex; align-items: center; border: 1px solid #555; padding: 15px; border-radius: 8px; background-color: #2a2a2a; color: #fff;">
+        <img src="media/distant_worlds_2/DW2_header.webp" width="150" alt="Distant Worlds 2 Header" style="margin-right: 15px; border-radius: 5px;">
+        <img src="media/distant_worlds_2/DW2_Screenshot1.webp" width="150" alt="Distant Worlds 2 Screenshot" style="margin-right: 15px; border-radius: 5px;">
+        <div>
+            <h3 style="margin: 0 0 5px 0; color: #fff;">Distant Worlds 2</h3>
+            <p style="margin: 0 0 10px 0; color: #ccc;">Vast, pausable real-time 4X space strategy game</p>
+            <a href="https://store.steampowered.com/app/1531540/Distant_Worlds_2/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Steam Link</a>
+        </div>
+    </div>
+    <div style="display: flex; align-items: center; border: 1px solid #555; padding: 15px; border-radius: 8px; background-color: #2a2a2a; color: #fff;">
+        <img src="media/fps_infinite/FPSI_header.webp" width="150" alt="FPS Infinite Header" style="margin-right: 15px; border-radius: 5px;">
+        <img src="media/fps_infinite/FPSI_Screenshot1.webp" width="150" alt="FPS Infinite Screenshot" style="margin-right: 15px; border-radius: 5px;">
+        <div>
+            <h3 style="margin: 0 0 5px 0; color: #fff;">FPS Infinite</h3>
+            <p style="margin: 0 0 10px 0; color: #ccc;">Procedural FPS with VR support</p>
+            <a href="https://store.steampowered.com/app/1256380/FPS_Infinite/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Steam Link</a>
+        </div>
+    </div>
+    <div style="display: flex; align-items: center; border: 1px solid #555; padding: 15px; border-radius: 8px; background-color: #2a2a2a; color: #fff;">
+        <img src="media/snaake_and_friends/S&F_header.webp" width="150" alt="Snaaker Friends Header" style="margin-right: 15px; border-radius: 5px;">
+        <img src="media/snaake_and_friends/S&F_Screenshot1.webp" width="150" alt="Snaaker Friends Screenshot" style="margin-right: 15px; border-radius: 5px;">
+        <div>
+            <h3 style="margin: 0 0 5px 0; color: #fff;">Snaaker Friends</h3>
+            <p style="margin: 0 0 10px 0; color: #ccc;">Multiplayer Snake-inspired game</p>
+            <a href="https://store.steampowered.com/app/1443760/Snaaker__Friends/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Steam Link</a>
+        </div>
+    </div>
+    <div style="display: flex; align-items: center; border: 1px solid #555; padding: 15px; border-radius: 8px; background-color: #2a2a2a; color: #fff;">
+        <img src="media/children_of_galaxy/CHG_header.webp" width="150" alt="Children of the Galaxy Header" style="margin-right: 15px; border-radius: 5px;">
+        <img src="media/children_of_galaxy/CHG_Screenshot1.webp" width="150" alt="Children of the Galaxy Screenshot" style="margin-right: 15px; border-radius: 5px;">
+        <div>
+            <h3 style="margin: 0 0 5px 0; color: #fff;">Children of the Galaxy</h3>
+            <p style="margin: 0 0 10px 0; color: #ccc;">Turn-based strategy game</p>
+            <a href="https://www.emptykeys.com/games/children-of-the-galaxy/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Website Link</a>
+        </div>
+    </div>
+    <div style="display: flex; align-items: center; border: 1px solid #555; padding: 15px; border-radius: 8px; background-color: #2a2a2a; color: #fff;">
+        <img src="media/virtual_desktop/VD_header.webp" width="150" alt="Virtual Desktop Header" style="margin-right: 15px; border-radius: 5px;">
+        <img src="media/virtual_desktop/VD_Screenshot1.webp" width="150" alt="Virtual Desktop Screenshot" style="margin-right: 15px; border-radius: 5px;">
+        <div>
+            <h3 style="margin: 0 0 5px 0; color: #fff;">Virtual Desktop</h3>
+            <p style="margin: 0 0 10px 0; color: #ccc;">VR desktop streaming app powered by Stride</p>
+            <a href="https://www.vrdesktop.net/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Website Link</a>
+        </div>
+    </div>
+</div>
 
 ## Open-Source Games and Prototypes
 

--- a/en/community-resources/games-and-demos.md
+++ b/en/community-resources/games-and-demos.md
@@ -9,7 +9,7 @@
         <div>
             <h3 style="margin: 0 0 5px 0; color: #fff;">Distant Worlds 2</h3>
             <p style="margin: 0 0 10px 0; color: #ccc;">Vast, pausable real-time 4X space strategy game</p>
-            <a href="https://store.steampowered.com/app/1531540/Distant_Worlds_2/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Steam Link</a>
+            <a href="https://store.steampowered.com/app/1531540/Distant_Worlds_2/" style="color: #ff4d4d; text-decoration: none; font-weight: bold;">Steam Link</a>
         </div>
     </div>
     <div style="display: flex; align-items: center; border: 1px solid #555; padding: 15px; border-radius: 8px; background-color: #2a2a2a; color: #fff;">
@@ -18,7 +18,7 @@
         <div>
             <h3 style="margin: 0 0 5px 0; color: #fff;">FPS Infinite</h3>
             <p style="margin: 0 0 10px 0; color: #ccc;">Procedural FPS with VR support</p>
-            <a href="https://store.steampowered.com/app/1256380/FPS_Infinite/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Steam Link</a>
+            <a href="https://store.steampowered.com/app/1256380/FPS_Infinite/" style="color: #ff4d4d; text-decoration: none; font-weight: bold;">Steam Link</a>
         </div>
     </div>
     <div style="display: flex; align-items: center; border: 1px solid #555; padding: 15px; border-radius: 8px; background-color: #2a2a2a; color: #fff;">
@@ -27,7 +27,7 @@
         <div>
             <h3 style="margin: 0 0 5px 0; color: #fff;">Snaaker Friends</h3>
             <p style="margin: 0 0 10px 0; color: #ccc;">Multiplayer Snake-inspired game</p>
-            <a href="https://store.steampowered.com/app/1443760/Snaaker__Friends/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Steam Link</a>
+            <a href="https://store.steampowered.com/app/1443760/Snaaker__Friends/" style="color: #ff4d4d; text-decoration: none; font-weight: bold;">Steam Link</a>
         </div>
     </div>
     <div style="display: flex; align-items: center; border: 1px solid #555; padding: 15px; border-radius: 8px; background-color: #2a2a2a; color: #fff;">
@@ -36,7 +36,7 @@
         <div>
             <h3 style="margin: 0 0 5px 0; color: #fff;">Children of the Galaxy</h3>
             <p style="margin: 0 0 10px 0; color: #ccc;">Turn-based strategy game</p>
-            <a href="https://www.emptykeys.com/games/children-of-the-galaxy/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Website Link</a>
+            <a href="https://www.emptykeys.com/games/children-of-the-galaxy/" style="color: #ff4d4d; text-decoration: none; font-weight: bold;">Website Link</a>
         </div>
     </div>
     <div style="display: flex; align-items: center; border: 1px solid #555; padding: 15px; border-radius: 8px; background-color: #2a2a2a; color: #fff;">
@@ -45,7 +45,7 @@
         <div>
             <h3 style="margin: 0 0 5px 0; color: #fff;">Virtual Desktop</h3>
             <p style="margin: 0 0 10px 0; color: #ccc;">VR desktop streaming app powered by Stride</p>
-            <a href="https://www.vrdesktop.net/" style="color: #4da6ff; text-decoration: none; font-weight: bold;">Website Link</a>
+            <a href="https://www.vrdesktop.net/" style="color: #ff4d4d; text-decoration: none; font-weight: bold;">Website Link</a>
         </div>
     </div>
 </div>

--- a/en/community-resources/media/children_of_galaxy/CHG_Screenshot1.webp
+++ b/en/community-resources/media/children_of_galaxy/CHG_Screenshot1.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3120f07eedc04d7fdf93ee0fbc4db126aa85aa8eb0ede636dbf64f3836495e1
+size 46194

--- a/en/community-resources/media/children_of_galaxy/CHG_header.webp
+++ b/en/community-resources/media/children_of_galaxy/CHG_header.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6232d042dacfbee6caf8f87be728433af577659dc1d0d0b480184c7714905d51
+size 32542

--- a/en/community-resources/media/distant_worlds_2/DW2_Screenshot1.webp
+++ b/en/community-resources/media/distant_worlds_2/DW2_Screenshot1.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daf4cf28a7db24143c022246f694101834992f8720de6505a0ff6af6e5c34041
+size 367142

--- a/en/community-resources/media/distant_worlds_2/DW2_header.webp
+++ b/en/community-resources/media/distant_worlds_2/DW2_header.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:206d6c2b757e8c61c367396ff89acb72ddf3efeba6a317fd866a0c59081cb504
+size 31098

--- a/en/community-resources/media/fps_infinite/FPSI_Screenshot1.webp
+++ b/en/community-resources/media/fps_infinite/FPSI_Screenshot1.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1cd253dd35ff6de10be720b15fa56743030e60e08e0aa9a04325376543a146a9
+size 264556

--- a/en/community-resources/media/fps_infinite/FPSI_header.webp
+++ b/en/community-resources/media/fps_infinite/FPSI_header.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa47daa2728abb71a39c386a3d902bc89238029dd55d27d603fd88743e029eb9
+size 32794

--- a/en/community-resources/media/snaake_and_friends/S&F_Screenshot1.webp
+++ b/en/community-resources/media/snaake_and_friends/S&F_Screenshot1.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cda12225bf684c6d1474468a9159d4cf27684b8ebbc087c7ef7ffb5bde1eed6
+size 91060

--- a/en/community-resources/media/snaake_and_friends/S&F_header.webp
+++ b/en/community-resources/media/snaake_and_friends/S&F_header.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b46500237cb8c262c55804b22f011744775b88d8fab7515d015a468666481014
+size 22590

--- a/en/community-resources/media/virtual_desktop/VD_Screenshot1.webp
+++ b/en/community-resources/media/virtual_desktop/VD_Screenshot1.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4170b57d8b0eaba0692757ea2ed904bf8f8c65419af56fce08c22808af6abd5
+size 55196

--- a/en/community-resources/media/virtual_desktop/VD_header.webp
+++ b/en/community-resources/media/virtual_desktop/VD_header.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09e0499a66e5c6df56ff87f495da181cac7d0e64563172d992a445a2738aab62
+size 72750


### PR DESCRIPTION
This PR updates the Released Games section in the Stride docs to make it clearer and more visually readable.

### Changes

- Added a proper header for the section
- Added screenshots for each game
- Improved layout and spacing
- Cleaned up how links and descriptions are displayed

### Why

The old version was just a list of links, which didn’t really showcase the games. This makes the section easier to browse and gives a better idea of what each project looks like.

### Result

The section now looks more structured and does a better job highlighting games made with Stride.

### Before

<img width="557" height="134" alt="Capture d’écran 2026-04-18 114333" src="https://github.com/user-attachments/assets/e3de9ac6-5b64-4dfb-8f2d-25b29eab4cdf" />

### After

<img width="1084" height="710" alt="wth" src="https://github.com/user-attachments/assets/ff129c8a-2e7d-4576-9df5-d8b641a4e5e1" />
