### PR TITLE
Updated the "Graphics API" page to reflect the recent changes

### DIFF
--- a/en/manual/graphics/graphics-api.md
+++ b/en/manual/graphics/graphics-api.md
@@ -41,7 +41,6 @@ Stride supports the following values:
 * Direct3D11
 * Direct3D12
 * Vulkan
-* Null
 
 ## Checking the API at runtime
 

--- a/en/manual/graphics/graphics-api.md
+++ b/en/manual/graphics/graphics-api.md
@@ -1,5 +1,7 @@
 ﻿# Graphics API
 
+<span class="badge text-bg-primary">Intermediate</span>
+
 **Graphics APIs** are responsible for performing basic rendering operations. They differ in platform availability and have their own benefits and drawbacks.
 
 ## Supported graphics APIs

--- a/en/manual/graphics/graphics-api.md
+++ b/en/manual/graphics/graphics-api.md
@@ -1,25 +1,63 @@
 ﻿# Graphics API
-To run your projects through a different API than the default one, add the following line to the `PropertyGroup` of your executable's `.csproj` file:
 
-`<StrideGraphicsApi>Vulkan</StrideGraphicsApi>`
+Graphics APIs are responsible for performing basic rendering operations. They differ in platform availability and have their own benefits and drawbacks.
+
+## Changing Graphics API
+
+To change the Graphics API that your project is using, add the following line to the `PropertyGroup` of a [platform package's](../files-and-folders/project-packages/index.md#platform-packages) `.csproj` file:
+
+`<StrideGraphicsApi>NameOfGraphicsAPIHere</StrideGraphicsApi>`
 
 ![image](https://user-images.githubusercontent.com/5742236/155832596-48165499-51ac-4026-9140-30b35dfa4f0b.png)
 
-Supported values are as follows:
+Stride supports the following values:
+
+* Direct3D11
+* Direct3D12
+* Vulkan
+* OpenGLES
+* Null
+
+## Supported Graphics APIs
+
+### Direct3D11
+
+**Available on platforms:** Windows
+
+Direct3D is a graphics API developed by Microsoft for Windows. Stride's implementation for version 11 is the most mature one out of all, which is why it's used as the default.
+
+### Direct3D12
+
+**Available on platforms:** Windows
+
+Version 12 of Direct3D is the newest version of the API. Currently, Stride's implementation for it isn't as stable as the one for 11, which is why it isn't used as default.
+
+### Vulkan
+
+**Available on platforms:** Windows, Linux, Android
+
+Vulkan is a modern graphics API that provides great performance benefits and control over how rendering is done. It's the most recommended choice for **Linux**.
+
+### OpenGLES
+
+**Available on platforms:** Windows, Linux, Android
+
+OpenGLES is a subset of OpenGL designed for embedded systems (such as smartphones).
+
+## Checking the API at runtime
+
+You can check which API your project is using from [`GraphicsDevice.Platform`](xref:Stride.Graphics.GraphicsDevice.Platform).
+
+## Building the engine with a different Graphics API
+
+When building the engine from source code, it will be built with support for only `Direct3D11`. You can change that using build parameters by setting `StrideGraphicsApiDependentBuildAll` to true.
+
+```bash
+dotnet build ./build/Stride.sln /p:StrideGraphicsApiDependentBuildAll=true
 ```
-Null
-Direct3D11
-Direct3D12
-OpenGL
-OpenGLES
-Vulkan
-```
 
-You *may* also have to add `<PackageReference Include="Stride.Shaders.Compiler" Version="x.x.x.x" />` to your *main* `.csproj`, and don't forget to replace `Version` appropriately.
+## See also
 
-![image](https://github.com/stride3d/stride/assets/5742236/fbe35875-fb07-4f2f-ae8a-e9ea34eed471)
-
-## Engine
-If you are using a local build of the engine you should run the build again with the following command:
-
-`msbuild /t:Build /p:StrideGraphicsApiDependentBuildAll=true Stride.sln`
+* [Platforms](../platforms/index.md)
+* [Project structure](../files-and-folders/project-structure.md)
+* [Project packages](../files-and-folders/project-packages/index.md)

--- a/en/manual/graphics/graphics-api.md
+++ b/en/manual/graphics/graphics-api.md
@@ -65,7 +65,7 @@ To only build selected api's, set the `StrideGraphicsApis` property to your desi
 ### [Powershell](#tab/powershell)
 
 ```powershell
-msbuild -p:StrideGraphicsApis=`"Api1`;Api2`"
+msbuild -p:StrideGraphicsApis=`"Api1;Api2`"
 ```
 
 ### [Bash](#tab/bash)

--- a/en/manual/graphics/graphics-api.md
+++ b/en/manual/graphics/graphics-api.md
@@ -34,13 +34,32 @@ To change the graphics API used by your project, add the following line to the `
 <StrideGraphicsApi>NameOfGraphicsAPIHere</StrideGraphicsApi>
 ```
 
-![](media/graphics-api-xml-property.webp)
-
-Stride supports the following values:
+The following values are supported:
 
 * Direct3D11
 * Direct3D12
 * Vulkan
+
+Here's an example of how this would look like:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0-windows</TargetFramework>
+        <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+        <ApplicationIcon>Resources/Icon.ico</ApplicationIcon>
+        <OutputType>WinExe</OutputType>
+        <RootNamespace>MyGame</RootNamespace>
+        <ApplicationManifest>app.manifest</ApplicationManifest>
+        
+        <StrideGraphicsApi>Vulkan</StrideGraphicsApi>
+    </PropertyGroup>
+
+    ...
+    
+</Project>
+```
 
 ## Checking the API at runtime
 

--- a/en/manual/graphics/graphics-api.md
+++ b/en/manual/graphics/graphics-api.md
@@ -1,60 +1,80 @@
 ﻿# Graphics API
 
-Graphics APIs are responsible for performing basic rendering operations. They differ in platform availability and have their own benefits and drawbacks.
+**Graphics APIs** are responsible for performing basic rendering operations. They differ in platform availability and have their own benefits and drawbacks.
 
-## Changing Graphics API
+## Supported graphics APIs
 
-To change the Graphics API that your project is using, add the following line to the `PropertyGroup` of a [platform package's](../files-and-folders/project-packages/index.md#platform-packages) `.csproj` file:
+Stride has support for the following APIs:
 
-`<StrideGraphicsApi>NameOfGraphicsAPIHere</StrideGraphicsApi>`
+### Direct3D11
 
-![image](https://user-images.githubusercontent.com/5742236/155832596-48165499-51ac-4026-9140-30b35dfa4f0b.png)
+**Available on platforms:** Windows
+
+Direct3D is a graphics API developed by Microsoft. Stride's implementation for version 11 is the most mature, which is why it's used as the default on Windows.
+
+### Direct3D12
+
+**Available on platforms:** Windows
+
+Version 12 of Direct3D is the newest release of the API. Currently, Stride's implementation for it isn't as stable as the one for 11, which is why it isn't used by default.
+
+### Vulkan
+
+**Available on platforms:** Windows, Linux, MacOS, Android, iOS
+
+Vulkan is a modern graphics API that provides great performance benefits and control over how rendering is performed. It's used as the default on non-Windows platforms.
+
+## Changing the graphics API
+
+To change the graphics API used by your project, add the following line to the `PropertyGroup` of a [platform package's](../files-and-folders/project-packages/index.md#platform-packages) `.csproj` file:
+
+```xml
+<StrideGraphicsApi>NameOfGraphicsAPIHere</StrideGraphicsApi>
+```
+
+![](media/graphics-api-xml-property.webp)
 
 Stride supports the following values:
 
 * Direct3D11
 * Direct3D12
 * Vulkan
-* OpenGLES
 * Null
-
-## Supported Graphics APIs
-
-### Direct3D11
-
-**Available on platforms:** Windows
-
-Direct3D is a graphics API developed by Microsoft for Windows. Stride's implementation for version 11 is the most mature one out of all, which is why it's used as the default.
-
-### Direct3D12
-
-**Available on platforms:** Windows
-
-Version 12 of Direct3D is the newest version of the API. Currently, Stride's implementation for it isn't as stable as the one for 11, which is why it isn't used as default.
-
-### Vulkan
-
-**Available on platforms:** Windows, Linux, Android
-
-Vulkan is a modern graphics API that provides great performance benefits and control over how rendering is done. It's the most recommended choice for **Linux**.
-
-### OpenGLES
-
-**Available on platforms:** Windows, Linux, Android
-
-OpenGLES is a subset of OpenGL designed for embedded systems (such as smartphones).
 
 ## Checking the API at runtime
 
 You can check which API your project is using from [`GraphicsDevice.Platform`](xref:Stride.Graphics.GraphicsDevice.Platform).
 
-## Building the engine with a different Graphics API
+```csharp
+public override void Update()
+{
+    DebugText.Print($"Graphics API: {GraphicsDevice.Platform}", new(50, 50));
+}
+```
 
-When building the engine from source code, it will be built with support for only `Direct3D11`. You can change that using build parameters by setting `StrideGraphicsApiDependentBuildAll` to true.
+## Building the engine with a different API
+
+When building the engine from source code, it will be built with support only for the default API for your OS. You can change that by setting `StrideGraphicsApiDependentBuildAll` to `true` in build parameters.
 
 ```bash
-dotnet build ./build/Stride.sln /p:StrideGraphicsApiDependentBuildAll=true
+msbuild -p:StrideGraphicsApiDependentBuildAll=true ./build/Stride.sln
 ```
+
+To only build selected api's, set the `StrideGraphicsApis` property to your desired value.
+
+### [Powershell](#tab/powershell)
+
+```powershell
+msbuild -p:StrideGraphicsApis=`"Api1`;Api2`"
+```
+
+### [Bash](#tab/bash)
+
+```bash
+msbuild -p:StrideGraphicsApis=\"Api1\;Api2\"
+```
+
+---
 
 ## See also
 

--- a/en/manual/graphics/graphics-api.md
+++ b/en/manual/graphics/graphics-api.md
@@ -65,13 +65,13 @@ To only build selected api's, set the `StrideGraphicsApis` property to your desi
 ### [Powershell](#tab/powershell)
 
 ```powershell
-msbuild -p:StrideGraphicsApis=`"Api1;Api2`"
+msbuild -p:StrideGraphicsApis=`"Api1`;Api2`" ./build/Stride.sln
 ```
 
 ### [Bash](#tab/bash)
 
 ```bash
-msbuild -p:StrideGraphicsApis=\"Api1\;Api2\"
+msbuild -p:StrideGraphicsApis=\"Api1\;Api2\" ./build/Stride.sln
 ```
 
 ---

--- a/en/manual/graphics/graphics-api.md
+++ b/en/manual/graphics/graphics-api.md
@@ -55,13 +55,13 @@ public override void Update()
 
 ## Building the engine with a different API
 
-When building the engine from source code, it will be built with support only for the default API for your OS. You can change that by setting `StrideGraphicsApiDependentBuildAll` to `true` in build parameters.
+When building the engine from source code, it will only contain support for your OS's default graphics API. To build all APIs, set `StrideGraphicsApiDependentBuildAll` to `true` in build parameters.
 
 ```bash
 msbuild -p:StrideGraphicsApiDependentBuildAll=true ./build/Stride.sln
 ```
 
-To only build selected api's, set the `StrideGraphicsApis` property to your desired value.
+To only build selected APIs, set the `StrideGraphicsApis` property to your desired values.
 
 ### [Powershell](#tab/powershell)
 

--- a/en/manual/graphics/media/graphics-api-xml-property.webp
+++ b/en/manual/graphics/media/graphics-api-xml-property.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3723c94b83e2e8ca2fb6e764216a85c2fa34477fb5bbfe569b6ea82ddf31ae37
+size 63450

--- a/en/manual/graphics/media/graphics-api-xml-property.webp
+++ b/en/manual/graphics/media/graphics-api-xml-property.webp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3723c94b83e2e8ca2fb6e764216a85c2fa34477fb5bbfe569b6ea82ddf31ae37
-size 63450


### PR DESCRIPTION
# Description

This PR rewrites the `Graphics API` page with more information and removes mentions of OpenGL, since it's been deprecated

This PR should probably be ignored until a new version of Stride releases, in case we want to update the live docs.

---

In the current version of the page, there is this line:

> You may also have to add `<PackageReference Include="Stride.Shaders.Compiler" Version="x.x.x.x" />` to your main `.csproj`, and don't forget to replace `Version` appropriately.

I assume that this package is either an old relic or it was used for precompiling shaders on platforms that required it. In my tests, I didn't need to use it for my projects to work. Let me know if this information should remain in the docs.

# Screenshot of the page

<img width="1283" height="1006" alt="image" src="https://github.com/user-attachments/assets/107ab35b-e8ed-417d-bf24-5a69f49cfcca" />

<img width="1268" height="968" alt="image" src="https://github.com/user-attachments/assets/f3140d7b-fd4c-40c3-b50e-b575da16de6b" />

<img width="1273" height="1041" alt="image" src="https://github.com/user-attachments/assets/0efff1d2-2929-4a4a-b691-345ad50ca4ed" />
