### PR TITLE
refactor: workflows - Use setup-stride action and cleanup

### DIFF
--- a/.github/workflows/stride-docs-release-azure.yml
+++ b/.github/workflows/stride-docs-release-azure.yml
@@ -3,9 +3,6 @@
 
 name: Build Stride Docs for Azure Web App Release 🚀
 
-permissions:
-  contents: write  # required to create releases/tags
-
 env:
   COMMON_SETTINGS_PATH: en/docfx.json
   VERSION: "2.0.0.${{ github.run_number }}"
@@ -23,19 +20,33 @@ on:
       - .gitignore
       - '.github/**'
   workflow_dispatch:
+    inputs:
+      skipPdfBuilding:
+        description: Skip PDF building
+        required: true
+        default: true
+        type: boolean
+      skipApiBuilding:
+        description: Skip API building
+        required: true
+        default: true
+        type: boolean
+      strideBranch:
+        description: Stride branch to checkout
+        required: true
+        default: master
+        type: string
+
+permissions:
+  contents: write  # required to create releases/tags
 
 jobs:
   build:
     # Run this job only if the repository is 'stride3d/stride-docs'
     if: github.repository == 'stride3d/stride-docs'
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
-    - name: .NET SDK Setup
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: 10.x
-
     # Checkout the Stride Docs repository from the branch that triggered the workflow
     - name: Checkout Stride Docs
       uses: actions/checkout@v6
@@ -43,70 +54,20 @@ jobs:
         path: ${{ env.DOCS_PATH }}
         lfs: true
 
-    - name: Set Version in docfx.json
-      run: |
-        $settingsContent = Get-Content -Path "${{ env.DOCS_PATH }}/${{ env.COMMON_SETTINGS_PATH }}" -Raw
-        $updatedDocFxJsonContent = $settingsContent -replace '2.0.0.x', "${{ env.VERSION }}"
-        Set-Content -Path "${{ env.DOCS_PATH }}/${{ env.COMMON_SETTINGS_PATH }}" -Value $updatedDocFxJsonContent
-      shell: pwsh
-
-    # Checkout the Stride repository from the default branch
-    - name: Checkout Stride (note the LFS)
-      uses: actions/checkout@v6
+    - name: Run Global Setup
+      id: setup
+      uses: ./stride-docs/.github/actions/setup-stride
       with:
-        repository: stride3d/stride
-        token: ${{ secrets.GITHUB_TOKEN }}
-        path: stride
-        lfs: true
-        ref: master
-
-    # Temporary solution till the new docfx is available
-    # - name: Checkout DocFX
-    #   uses: actions/checkout@v6
-    #   with:
-    #     repository: dotnet/docfx
-    #     # Tested commit
-    #     ref: 917cda864650279e0bbe50b852cb98601e5efa4d
-    #     path: docfx-build
-    #     fetch-depth: 0
-
-    # - name: Restore npm dependencies
-    #   run: npm install
-    #   working-directory:  docfx-build/templates
-
-    # - name: Build site templates
-    #   run: npm run build
-    #   working-directory:  docfx-build/templates
-
-    # - name: Build DocFX from PR
-    #   run: dotnet pack src/docfx -c Release /p:Version=2.9-stride -o drop/nuget
-    #   working-directory: docfx-build
-    #   shell: pwsh
-
-    # - name: Build Install DocFX
-    #   run: dotnet tool install -g docfx --version 2.9-stride --add-source drop/nuget
-    #   working-directory: docfx-build
-    #   shell: pwsh
-    # End of Temporary solution
-
-    - name: Install DocFX
-      # This installs the latest version of DocFX and may introduce breaking changes
-      # run: dotnet tool update -g docfx
-      # This installs a specific, tested version of DocFX.
-      run: dotnet tool update -g docfx --version 2.78.5
-
-    - name: Build documentation
-      run: ./build-all.bat
-      working-directory: ${{ env.DOCS_PATH }}
-
-    - name: Compress artifact
-      run: 7z a -r DocFX-app.zip ./${{ env.DOCS_PATH }}/_site/*
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        skip-pdf-building: ${{ inputs.skipPdfBuilding }}
+        skip-api-building: ${{ inputs.skipApiBuilding }}
+        stride-branch: ${{ inputs.strideBranch || 'master' }}
 
     - name: Upload artifact for deployment job
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: DocFX-app
-        path: DocFX-app.zip
+        path: ./${{ env.DOCS_PATH }}/_site
 
     - name: Create GitHub Release
       run: |
@@ -117,7 +78,7 @@ jobs:
 
   deploy:
     if: github.repository == 'stride3d/stride-docs'
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     needs: build
     environment:
@@ -126,15 +87,10 @@ jobs:
 
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         name: DocFX-app
-
-    # - name: List current directory
-    #   run: ls
-
-    - name: Decompress artifact
-      run: 7z x DocFX-app.zip "-o./${{ env.DOCS_PATH }}/_site"
+        path: ./${{ env.DOCS_PATH }}/_site
 
     - name: Deploy to Azure Web App
       id: deploy-to-webapp

--- a/.github/workflows/stride-docs-release-fast-track-azure.yml
+++ b/.github/workflows/stride-docs-release-fast-track-azure.yml
@@ -4,9 +4,6 @@
 # The Fast Track skips creating artifacts and compressing them
 name: Build Stride Docs (Fast Track) for Azure Web App Release 🚀
 
-permissions:
-  contents: write  # required to create releases/tags
-
 env:
   COMMON_SETTINGS_PATH: en/docfx.json
   VERSION: "2.0.0.${{ github.run_number }}"
@@ -14,22 +11,36 @@ env:
 
 on:
   workflow_dispatch:
+    inputs:
+      skipPdfBuilding:
+        description: Skip PDF building
+        required: true
+        default: true
+        type: boolean
+      skipApiBuilding:
+        description: Skip API building
+        required: true
+        default: true
+        type: boolean
+      strideBranch:
+        description: Stride branch to checkout
+        required: true
+        default: master
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
   build-deploy:
     # Run this job only if the repository is 'stride3d/stride-docs'
     if: github.repository == 'stride3d/stride-docs'
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     environment:
       name: 'Production'
 
     steps:
-    - name: .NET SDK Setup
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: 10.x
-
     # Checkout the Stride Docs repository from the branch that triggered the workflow
     - name: Checkout Stride Docs
       uses: actions/checkout@v6
@@ -37,61 +48,14 @@ jobs:
         path: ${{ env.DOCS_PATH }}
         lfs: true
 
-    - name: Set Version in docfx.json
-      run: |
-        $settingsContent = Get-Content -Path "${{ env.DOCS_PATH }}/${{ env.COMMON_SETTINGS_PATH }}" -Raw
-        $updatedDocFxJsonContent = $settingsContent -replace '2.0.0.x', "${{ env.VERSION }}"
-        Set-Content -Path "${{ env.DOCS_PATH }}/${{ env.COMMON_SETTINGS_PATH }}" -Value $updatedDocFxJsonContent
-      shell: pwsh
-
-    # Checkout the Stride repository from the default branch
-    - name: Checkout Stride (note the LFS)
-      uses: actions/checkout@v6
+    - name: Run Global Setup
+      id: setup
+      uses: ./stride-docs/.github/actions/setup-stride
       with:
-        repository: stride3d/stride
-        token: ${{ secrets.GITHUB_TOKEN }}
-        path: stride
-        lfs: true
-        ref: master
-
-    # Temporary solution till the new docfx is available
-    # - name: Checkout DocFX
-    #   uses: actions/checkout@v6
-    #   with:
-    #     repository: dotnet/docfx
-    #     # Tested commit
-    #     ref: 917cda864650279e0bbe50b852cb98601e5efa4d
-    #     path: docfx-build
-    #     fetch-depth: 0
-
-    # - name: Restore npm dependencies
-    #   run: npm install
-    #   working-directory:  docfx-build/templates
-
-    # - name: Build site templates
-    #   run: npm run build
-    #   working-directory:  docfx-build/templates
-
-    # - name: Build DocFX from PR
-    #   run: dotnet pack src/docfx -c Release /p:Version=2.9-stride -o drop/nuget
-    #   working-directory: docfx-build
-    #   shell: pwsh
-
-    # - name: Build Install DocFX
-    #   run: dotnet tool install -g docfx --version 2.9-stride --add-source drop/nuget
-    #   working-directory: docfx-build
-    #   shell: pwsh
-    # End of Temporary solution
-
-    - name: Install DocFX
-      # This installs the latest version of DocFX and may introduce breaking changes
-      # run: dotnet tool update -g docfx
-      # This installs a specific, tested version of DocFX.
-      run: dotnet tool update -g docfx --version 2.78.5
-
-    - name: Build documentation
-      run: ./build-all.bat
-      working-directory: ${{ env.DOCS_PATH }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        skip-pdf-building: ${{ inputs.skipPdfBuilding }}
+        skip-api-building: ${{ inputs.skipApiBuilding }}
+        stride-branch: ${{ inputs.strideBranch }}
 
     - name: Deploy to Azure Web App
       id: deploy-to-webapp


### PR DESCRIPTION
refactor: workflows - Use setup-stride action and cleanup

- Replace manual setup with .github/actions/setup-stride in both YAMLs
- Add workflow_dispatch inputs for PDF/API skipping and branch selection
- Update runner to windows-2025-vs2026
- Switch to latest artifact upload/download actions
- Remove legacy, redundant, and commented-out steps for clarity

#### PR Classification
Workflow modernization and configuration enhancement for documentation deployment.

#### PR Summary
This pull request updates the Azure deployment workflows to use a custom setup action, adds configurable workflow inputs, and modernizes runner and action versions for improved maintainability and flexibility.
- stride-docs-release-azure.yml and stride-docs-release-fast-track-azure.yml: Added workflow_dispatch inputs, replaced manual setup with .github/actions/setup-stride, updated runner to windows-2025-vs2026, and upgraded artifact actions.
- Both workflow files: Streamlined build and deployment steps, removed redundant setup tasks, and clarified permissions.
