### PR TITLE
Added a troubleshooting page for nuget vulnerability warnings

### DIFF
--- a/en/manual/toc.yml
+++ b/en/manual/toc.yml
@@ -655,6 +655,8 @@ items:
         href: troubleshooting/unable-to-resolve-stride-game-studio.md
       - name: The Launcher is showing only 3.x version
         href: troubleshooting/unable-to-resolve-stride-game-studio.md
+      - name: Solution contains packages with vulnerabilities
+        href: troubleshooting/solution-contains-packages-with-vulnerabilities.md
 
   - name: Glossary
     href: glossary/index.md

--- a/en/manual/troubleshooting/index.md
+++ b/en/manual/troubleshooting/index.md
@@ -15,3 +15,4 @@ These pages describe how to fix problems with Stride.
 * [SceneCameraRenderer error](error-a-scenecamerarenderer-in-use-has-no-camera-set.md)
 * [Unable to resolve Stride.GameStudio](unable-to-resolve-stride-game-studio.md)
 * [The Launcher is showing only 3.x version](unable-to-resolve-stride-game-studio.md)
+* [Solution contains packages with vulnerabilities](solution-contains-packages-with-vulnerabilities.md)

--- a/en/manual/troubleshooting/media/terminal-vulnerable-packages-warnings.webp
+++ b/en/manual/troubleshooting/media/terminal-vulnerable-packages-warnings.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dba02b92c7754ba7fe96f2e9cd34e5f8373cf2dec30a468f34b064cde4c0948c
+size 171772

--- a/en/manual/troubleshooting/media/visual-studio-error-list-vulnerable-packages-warnings.webp
+++ b/en/manual/troubleshooting/media/visual-studio-error-list-vulnerable-packages-warnings.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8974183cbfbb78948dd503dd5c796f3efa512619e10f8108a2b04ccf44a7b150
+size 105382

--- a/en/manual/troubleshooting/media/visual-studio-vulnerable-packages-warning.webp
+++ b/en/manual/troubleshooting/media/visual-studio-vulnerable-packages-warning.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dde8019e497060e7ccf12d762867df0afe3abde3bdde21b0fbce04f7e04007d9
+size 17170

--- a/en/manual/troubleshooting/solution-contains-packages-with-vulnerabilities.md
+++ b/en/manual/troubleshooting/solution-contains-packages-with-vulnerabilities.md
@@ -1,6 +1,6 @@
 # Solution contains packages with vulnerabilities
 
-Sometimes, especially when using an older version of Stride, you might notice a warning in Visual Studio that looks like this:
+Sometimes, especially when using an older version of Stride, you might notice warnings in Visual Studio that look like this:
 
 ![This solution contains packages with vulnerabilities.](media/visual-studio-vulnerable-packages-warning.webp)
 
@@ -12,7 +12,7 @@ Sometimes, especially when using an older version of Stride, you might notice a 
 
 ## What does it mean?
 
-This means that one of the **external packages** your project is using has been marked as vulnerable and **could be exploited by bad actors in your exported game**.
+This means that one of the **external packages** your project is using has been marked as vulnerable and **could be exploited by bad actors in your released game**.
 
 ## Why does it happen?
 
@@ -20,9 +20,14 @@ Stride depends on **other libraries** in order to work and sometimes, those libr
 
 ## How to fix it?
 
-Either **update to the latest version of Stride**, or if you are already on it, **ignore the warning and wait for the next release of the engine**.
+1. Update your project to the latest version of Stride. See [Update Stride](../install-and-update/update-stride.md).
+2. Check in the engine's [source code](https://github.com/stride3d/stride) if the warning is limited to Game Studio, in which case it can be safely ignored.
+3. Ignore the warning while you work on your game and wait for the next release of the engine.
 
-This warning **does not impact your ability to develop and build**. You are still able to use the editor, test your game and even release it, although it is recommended to **update the engine as soon as a new update comes out**.
+This warning **does not impact your ability to develop and build**. You are still able to use the editor, test your game and even release it (see the note below).
+
+> [!NOTE]
+> If you want to release a game with vulnerable packages, make sure to **check how the vulnerability would impact your users** and decide if the warnings can be ignored. If you can't wait, you will have to **build the engine from source**. 
 
 ## See also
 

--- a/en/manual/troubleshooting/solution-contains-packages-with-vulnerabilities.md
+++ b/en/manual/troubleshooting/solution-contains-packages-with-vulnerabilities.md
@@ -1,0 +1,29 @@
+# Solution contains packages with vulnerabilities
+
+Sometimes, especially when using an older version of Stride, you might notice a warning in Visual Studio that looks like this:
+
+![This solution contains packages with vulnerabilities.](media/visual-studio-vulnerable-packages-warning.webp)
+
+![Warnings in the Error List, saying that a package has a known high severity vulnerability.](media/visual-studio-error-list-vulnerable-packages-warnings.webp)
+
+...or when building your project:
+
+![The terminal displaying multiple warnings, saying that a package has a known high severity vulnerability.](media/terminal-vulnerable-packages-warnings.webp)
+
+## What does it mean?
+
+This means that one of the **external packages** your project is using has been marked as vulnerable and **could be exploited by bad actors in your exported game**.
+
+## Why does it happen?
+
+Stride depends on **other libraries** in order to work and sometimes, those libraries are **marked as vulnerable on [nuget.org](https://nuget.org)**.
+
+## How to fix it?
+
+Either **update to the latest version of Stride**, or if you are already on it, **ignore the warning and wait for the next release of the engine**.
+
+This warning **does not impact your ability to develop and build**. You are still able to use the editor, test your game and even release it, although it is recommended to **update the engine as soon as a new update comes out**.
+
+## See also
+
+* [Update stride](../install-and-update/update-stride.md)

--- a/en/manual/troubleshooting/solution-contains-packages-with-vulnerabilities.md
+++ b/en/manual/troubleshooting/solution-contains-packages-with-vulnerabilities.md
@@ -27,7 +27,7 @@ Stride depends on **other libraries** in order to work and sometimes, those libr
 This warning **does not impact your ability to develop and build**. You are still able to use the editor, test your game and even release it (see the note below).
 
 > [!NOTE]
-> If you want to release a game with vulnerable packages, make sure to **check how the vulnerability would impact your users** and decide if the warnings can be ignored. If you can't wait, you will have to **build the engine from source**. 
+> If you want to release a game with vulnerable packages, make sure to **check how the vulnerability would impact your users** and decide if the warnings can be ignored. If you can't wait, you will have to **replace the problematic dependencies in the source and rebuild the engine**.
 
 ## See also
 


### PR DESCRIPTION
# Description

A lot of users have been asking for help relating to package vulnerability warnings in the latest release. This is a part of nuget which we don't have control over and that will continue creating confusion between releases in the future. This PR adds a page about it that we can link users to.