### PR TITLE
fix: Disabled the `Edit this page` button on engine architecture pages

### DIFF
--- a/en/docfx.json
+++ b/en/docfx.json
@@ -75,6 +75,9 @@
         "diagnostics/**/*.md": "Stride diagnostics",
         "contributors/**/*.md": "Stride contributors",
         "community-resources/**/*.md": "Stride Community resources"
+      },
+      "_disableContribution": {
+        "contributors/engine/architecture/**/*.md": "true"
       }
     },
     "sitemap": {


### PR DESCRIPTION
# Description
Engine architecture pages are copied from the main stride repository during building, meaning that they do not exist in the docs source. This made the `Edit this page` button link to the wrong pages. Currently, there is no easy way of manually specifying the repository page path in docfx. The only alternative is to disable it altogether for those copied pages.