### PR TITLE
Updated `ways to contribute`

### DIFF
--- a/en/contributors/donate.md
+++ b/en/contributors/donate.md
@@ -1,16 +1,3 @@
-# Donating to Stride
-
-In order to support our contributors or if we want to finance a specific feature, we collect donations from individuals as well as organisations. 
-
-## Open Collective
-
-We gather funding through a website called [OpenCollective](https://opencollective.com/stride3d). This website displays where all the money is coming from and where it is going to: 100% transparency guaranteed.
-
-## Projects
-
-Stride's Open Collective hosts different [Projects](https://opencollective.com/stride3d/projects), think of them as funding goals for specific features or contributions. Each project typically has a related GitHub ticket for more details on what's required for its development.
-
-If you're interested in working on or contributing to a particular feature, you can let us know by either replying:
-
- - In each projects related GitHub thread and mention @stride3d/stride-contributors 
- - In the Stride [Contributors channel on Discord](https://discord.gg/bDhMhGVHvD)
+---
+redirect_url: ways-to-contribute/donate.md
+---

--- a/en/contributors/engine/bug-bounties.md
+++ b/en/contributors/engine/bug-bounties.md
@@ -10,18 +10,21 @@ For bugs that have not been filed yet, issues without bounties, or if the bounty
 Feel free to contact us either through the thread or on Discord in `#github-pr-and-issues` with the `@Developer` tag if you need more precision.
 
 ## Taking a bounty
-- If the issue has not been filed yet, create a new one in the [issues tab on github](https://github.com/stride3d/stride/issues)
-- Reply in the thread and tag `@stride3d/stride-contributors` with your email or Discord handle
+
+- If the issue has not been filed yet, create a new one in the [issues tab on github](https://github.com/stride3d/stride/issues).
+- Reply in the thread and tag `@stride3d/stride-contributors` with your email or Discord handle.
 - We'll get back to you and reserve that issue to your name.
 - You can then create a new pull request and we'll review it.
 - Once merged in you will receive 60% of the bounty and the other 40% on the next official release of the engine.
 
 ## Getting paid
+
 Stride uses the Open source collective as our Fiscal host to approve the payments. They process payouts twice weekly, once they have been approved by the admins of the Collective. They can only make payouts to countries served by PayPal and [Wise](https://documentation.opencollective.com/expenses-and-getting-paid/getting-paid-through-wise).
 
-Our fiscal host resides in the US. You may have to file a tax form depending on the sum of the bounty, see [Tax Information](https://docs.opencollective.com/help/expenses-and-getting-paid/tax-information)
+Our fiscal host resides in the US. You may have to file a tax form depending on the sum of the bounty, see [Tax Information](https://docs.opencollective.com/help/expenses-and-getting-paid/tax-information).
 
 You can go to the specific bug bounty on Stride's [Open Collective](https://opencollective.com/stride3d) for payment:
+
 ![gettingpaid-bounty](https://user-images.githubusercontent.com/3499539/158011382-732c2448-8368-418f-9eae-7713ea7b349d.gif)
 
-More detail in Open Collective's [documentation](https://documentation.opencollective.com/expenses-and-getting-paid/submitting-expenses)
+More detail in Open Collective's [documentation](https://documentation.opencollective.com/expenses-and-getting-paid/submitting-expenses).

--- a/en/contributors/engine/bug-bounties.md
+++ b/en/contributors/engine/bug-bounties.md
@@ -1,4 +1,5 @@
-﻿# Bug bounties
+﻿# Paid work
+
 If you are a developer with solid experience in C#, rendering techniques, or game development, we want to hire you! We have allocated funds from supporters on [OpenCollective](https://opencollective.com/stride3d) and will pay you for your work on certain issues.
 
 ## What you can work on

--- a/en/contributors/engine/contribute-code.md
+++ b/en/contributors/engine/contribute-code.md
@@ -1,22 +1,3 @@
-﻿# Contribute Code
-If you are a developer and you want to help building Stride even more awesome, than you can do so in various ways.
-
-## Check our issue tracker
-If you are just getting started with Stride, issues marked with ['good first issue'](https://github.com/stride3d/stride/labels/good%20first%20issue) can be a good entry point.
-Please take a look at our [issue tracker](https://github.com/stride3d/stride/issues) for other issues.
-
-We also have funded [Open Collective Projects](https://opencollective.com/stride3d/projects/) in case you want to earn a little extra. These are either Bug bounties
-
-## Notify users
-Once you start working on an issue, leave a message on the appropriate issue or create one if none exists to:
-* You can always check on Github or Discord if you need to get started somewhere or if you need a general sense of approaching an issue. 
-* Make sure that no one else is working on that same issue
-* Lay out your plans and discuss it with collaborators and users to make sure it is properly architectured and would fit well in the project
-
-## Coding style
-Please use and follow Stride's `.editorconfig` when making changes to files.
-
-## Submitting Changes
-* Push your changes to a specific branch in your fork.
-* Use that branch to create and fill out a pull request to the official repository.
-* After creating that pull request and if it's your first time contributing a [CLA assistant](https://cla-assistant.io/) will ask you to sign the [.NET Foundation Contribution License Agreement](https://dotnetfoundation.org/docs/default-source/default-document-library/contribution-license-agreement.pdf?sfvrsn=40626e42_3).
+﻿---
+redirect_url: ../ways-to-contribute/code.md
+---

--- a/en/contributors/engine/index.md
+++ b/en/contributors/engine/index.md
@@ -22,14 +22,14 @@ These pages provide information about how to contribute to the engine as well as
 
 ### Paid work 💵
 
-We also have funded [Open Collective Projects](https://opencollective.com/stride3d/projects/) in case you want to earn a little extra. These are either bug bounties, requests for new features or other tasks that are deemed as important. We can also create a new project for you in case you are working on something large that the community would like to see.
+We also have funded [Open Collective Projects](https://opencollective.com/stride3d/projects/) in case **you want to earn a little extra**. These are either bug bounties, requests for new features or other tasks that are deemed important enough. **We can also create a new project for you** in case you are working on something large that the community would like to see.
 
 For more information, visit [Paid work](bug-bounties.md).
 
 ## Coding style
 
-Please use and follow the coding style outlined in the `.editorconfig` file in the root of the repository ([link](https://github.com/stride3d/stride/blob/master/.editorconfig)). Your IDE of choice should be able to use it in order to automatically enforce the rules that are outlined in it.
+Please use and follow the coding style outlined in **the `.editorconfig` file** in the root of the repository ([link](https://github.com/stride3d/stride/blob/master/.editorconfig)). Your IDE of choice should be able to use it in order to automatically enforce its rules.
 
 ## Architecture documentation
 
-We store architecture documentation in the main engine repository under `docs/`. They are automatically copied when building the documentation website to the [🏗️ Architecture](architecture/index.md) section for easier viewing.
+We store architecture documentation in the main engine repository under `docs/`. They are **automatically copied** when building the documentation website to the [🏗️ Architecture](architecture/index.md) section for easier viewing.

--- a/en/contributors/engine/index.md
+++ b/en/contributors/engine/index.md
@@ -1,27 +1,35 @@
 # Contribute to Stride engine
-Here you can find various pages describing building the source locally for different systems. You can also find information about Stride's architecture.
 
-## [Contribute code](contribute-code.md)
-Want to help out fixing bugs or making new features? Check out how you can do so.
+Welcome to the engine contributing documentation!
 
-## [Bug bounties](bug-bounties.md)
-Here you can learn about the process on our bug bounty process.
+These pages provide information about how to contribute to the engine as well as resources related to how Stride works and its architecture.
 
-## [Building on Windows](building-source-windows.md)
-Building and running the Stride engine locally on Windows using [Visual Studio](building-source-windows.md) or other [IDEs](building-source-windows-other-ide.md).
+## How to contribute
 
-[//]: # (### [Building on Linux]&#40;building-source-linux.md&#41;)
+1. **Find something you would like to work on.** If you are just getting started with Stride, issues marked with ['good first issue'](https://github.com/stride3d/stride/labels/good%20first%20issue) can be a good entry point.
 
-[//]: # (Building the Stride engine locally on Linux)
+2. **Notify other users.** Leave a message on the appropriate issue or create one if none exists.
 
-## [Localization](localization.md)
-Learn how manage translations for the engine.
+    > [!WARNING]
+    > This step is important to **ensure no one else is working on that same issue** and **allow other contributors and users to chime in**, so that your changes are properly architectured and fit well with the rest of the project.
 
-## [Hot reloading shaders](hot-reloading-shaders.md)
-Learn about hot reloading shaders.
+3. **Push your changes to a specific branch in your fork.**
 
-## [Source debugging](source-debugging.md)
-Learn how to do source debugging.
+4. **Submit a pull request and address reviews.** Other contributors and users may require you to make changes to make sure everything is working correctly and to ensure consistency.
 
-## [Visual studio plugin](visual-studio-plugin.md)
-Learn about the Visual studio plugin for shader development.
+    > [!NOTE]
+    > After creating that pull request and if it's your first time contributing a [CLA assistant](https://cla-assistant.io/) will ask you to sign the [.NET Foundation Contribution License Agreement](https://dotnetfoundation.org/docs/default-source/default-document-library/contribution-license-agreement.pdf?sfvrsn=40626e42_3).
+
+### Paid work 💵
+
+We also have funded [Open Collective Projects](https://opencollective.com/stride3d/projects/) in case you want to earn a little extra. These are either bug bounties, requests for new features or other tasks that are deemed as important. We can also create a new project for you in case you are working on something large that the community would like to see.
+
+For more information, visit [Paid work](bug-bounties.md).
+
+## Coding style
+
+Please use and follow the coding style outlined in the `.editorconfig` file in the root of the repository ([link](https://github.com/stride3d/stride/blob/master/.editorconfig)). Your IDE of choice should be able to use it in order to automatically enforce the rules that are outlined in it.
+
+## Architecture documentation
+
+We store architecture documentation in the main engine repository under `docs/`. They are automatically copied when building the documentation website to the [🏗️ Architecture](architecture/index.md) section for easier viewing.

--- a/en/contributors/index.md
+++ b/en/contributors/index.md
@@ -6,44 +6,39 @@ There are no full-time developers dedicated solely to Stride's advancement; inst
 
 In order to thrive, Stride requires help from other community members. There are various ways you can help:
 
-## 🤝 Community activity
+<div class="row g-4 mb-4">
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-body">
+                <h2 class="card-title h4">💸 Donate</h2>
+                <p class="card-text">We utilize <b>Open Collective</b> for fundraising. The funds collected are allocated towards bug bounties and compensating individuals contracted for paid work.</p>
+            </div>
+            <p class="px-3 mb-4"><a class="stretched-link" href="ways-to-contribute/donate.md">Learn more</a></p>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-body">
+                <h2 class="card-title h4">🤖 Contribute code</h2>
+                <p class="card-text">If you're passionate about C# and want to contribute by building features or fixing bugs in Stride, dive into the source code and get involved!</p>
+            </div>
+            <p class="px-3 mb-4"><a class="stretched-link" href="ways-to-contribute/code.md">Learn more</a></p>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-body">
+                <h2 class="card-title h4">🪶 Contribute content</h2>
+                <p class="card-text">If you aren't comfortable in creating code or have knack for writing, consider contributing to the website or documentation!</p>
+            </div>
+            <p class="px-3 mb-4"><a class="stretched-link" href="ways-to-contribute/content.md">Learn more</a></p>
+        </div>
+    </div>
+</div>
 
-To make Stride better, just use it and tell others about it in your blogs, videos, and events. Get involved in discussions on [Discord](https://discord.gg/f6aerfE) and [GitHub Discussions](https://github.com/stride3d/stride/discussions). Being a user and spreading the word is vital for our engine, as we don't have a big marketing budget and rely on the community to grow.
+## Other ways of contributing
 
-## 🕹️ Make games
-
-The best way to promote Stride is by creating a cool demo or, even better, a full game. Having people see and play an actual game made with Stride is the most effective form of advertisement.
-
-You can showcase your projects on our [Community resources](../community-resources/index.md) page.
-
-## 💸 Donate
-
-We utilize [Open Collective](donate.md) for fundraising. The funds collected are allocated towards bug bounties and compensating individuals contracted for paid work.
-
-## 🐛 Submit bug reports
-
-Making Stride more stable greatly improves usability and user satisfaction. If you encounter a bug during development, please contribute by reporting it on [GitHub](https://github.com/stride3d/stride/issues).
-
-## 🔭 PR reviews
-
-Contributing to Pull Requests (PRs) is excellent as it enables active participation without local builds. Reviewing and offering feedback in this collaborative process enhances code quality and maintains project standards, fostering a sense of community and knowledge sharing.
-
-You can find open PRs [here](https://github.com/stride3d/stride/pulls).
-
-## 🤖 Contribute code
-
-If you're passionate about C# and want to contribute by building features or fixing bugs in Stride, dive into the source code and get involved!
-
-Have a look at GitHub issues labelled [Good first issue](https://github.com/stride3d/stride/labels/good%20first%20issue) or funded [Open Collective projects](https://opencollective.com/stride3d/projects).
-
-## 🪶 Contribute to documentation
-
-Enhance the official documentation and tutorials by expanding the manual or creating textual/video guides. Your contributions will greatly improve accessibility and understanding for users.
-
-Learn more about how to contribute to the docs [here](documentation/index.md).
-
-## 🌐 Contribute to the website
-
-Enhance the official Stride website. Is design more your thing, or do you have an interesting blog post? It will all help us spread the word about Stride.
-
-Find out how to contribute to the website [here](website/index.md).
+* **Creating games, tutorials and blogs** - just by using the engine you massively help us with spreading the word about it. You can showcase your projects on our [Community resources](../community-resources/index.md).
+* **Community activity** - we don't have a big marketing budget and rely on the community to grow. You can get involved in discussions on our [Discord](https://discord.gg/f6aerfE) and [GitHub Discussions](https://github.com/stride3d/stride/discussions).
+* **Submit bug reports** - Stride doesn't use telemetry, so the only way to let us know that something is broken is by [creating an issue on GitHub](https://github.com/stride3d/stride/issues).
+* **PR reviews** - going over pull requests to the engine, docs and website takes a lot of time, so having an extra pair of eyes to look over these changes can speed up this process.

--- a/en/contributors/index.md
+++ b/en/contributors/index.md
@@ -38,7 +38,7 @@ In order to thrive, Stride requires help from other community members. There are
 
 ## Other ways of contributing
 
-* **🎮 Creating games, tutorials and blogs** - just by using the engine you massively help us with spreading the word about it. You can showcase your projects on our [Community resources](../community-resources/index.md).
+* **🎮 Creating games, tutorials and blogs** - you are massively helping us with spreading the word about the engine just by using it. You can showcase your projects in our [Community resources](../community-resources/index.md).
 * **🗣️ Community activity** - we don't have a big marketing budget and rely on the community to grow. You can get involved in discussions on our [Discord](https://discord.gg/f6aerfE) and [GitHub Discussions](https://github.com/stride3d/stride/discussions).
 * **🐞 Submit bug reports** - Stride doesn't use telemetry, so the only way to let us know that something is broken is by [creating an issue on GitHub](https://github.com/stride3d/stride/issues).
 * **🔍 PR reviews** - going over pull requests to the engine, docs and website takes a lot of time, so having an extra pair of eyes to look over these changes can speed up this process.

--- a/en/contributors/index.md
+++ b/en/contributors/index.md
@@ -38,7 +38,7 @@ In order to thrive, Stride requires help from other community members. There are
 
 ## Other ways of contributing
 
-* **Creating games, tutorials and blogs** - just by using the engine you massively help us with spreading the word about it. You can showcase your projects on our [Community resources](../community-resources/index.md).
-* **Community activity** - we don't have a big marketing budget and rely on the community to grow. You can get involved in discussions on our [Discord](https://discord.gg/f6aerfE) and [GitHub Discussions](https://github.com/stride3d/stride/discussions).
-* **Submit bug reports** - Stride doesn't use telemetry, so the only way to let us know that something is broken is by [creating an issue on GitHub](https://github.com/stride3d/stride/issues).
-* **PR reviews** - going over pull requests to the engine, docs and website takes a lot of time, so having an extra pair of eyes to look over these changes can speed up this process.
+* **🎮 Creating games, tutorials and blogs** - just by using the engine you massively help us with spreading the word about it. You can showcase your projects on our [Community resources](../community-resources/index.md).
+* **🗣️ Community activity** - we don't have a big marketing budget and rely on the community to grow. You can get involved in discussions on our [Discord](https://discord.gg/f6aerfE) and [GitHub Discussions](https://github.com/stride3d/stride/discussions).
+* **🐞 Submit bug reports** - Stride doesn't use telemetry, so the only way to let us know that something is broken is by [creating an issue on GitHub](https://github.com/stride3d/stride/issues).
+* **🔍 PR reviews** - going over pull requests to the engine, docs and website takes a lot of time, so having an extra pair of eyes to look over these changes can speed up this process.

--- a/en/contributors/toc.yml
+++ b/en/contributors/toc.yml
@@ -1,7 +1,7 @@
 pdf: true
 pdfFileName: contributing-in-stride.pdf
 items:
-- name: 🌟 Ways to Contribute
+- name: 🌟 Ways to contribute
   href: index.md
   expanded: true
   items:

--- a/en/contributors/toc.yml
+++ b/en/contributors/toc.yml
@@ -4,10 +4,15 @@ items:
 - name: 🌟 Ways to Contribute
   href: index.md
   expanded: true
+  items:
+    - name: Donate
+      href: ways-to-contribute/donate.md
+    - name: Contribute code
+      href: ways-to-contribute/code.md
+    - name: Contribute content
+      href: ways-to-contribute/content.md
 - name: 🛣️ Roadmap
   href: roadmap.md
-- name: 💸 Donate
-  href: donate.md
 - name: 🧑‍💻 Core Team
   href: core-team.md
 - name: ⚙️ Major Release Workflow

--- a/en/contributors/toc.yml
+++ b/en/contributors/toc.yml
@@ -3,7 +3,6 @@ pdfFileName: contributing-in-stride.pdf
 items:
 - name: 🌟 Ways to contribute
   href: index.md
-  expanded: true
   items:
     - name: Donate
       href: ways-to-contribute/donate.md
@@ -29,9 +28,7 @@ items:
   expanded: false
   href: engine/index.md
   items:
-  - name: Contribute to code
-    href: engine/contribute-code.md
-  - name: Bug bounties
+  - name: Paid work
     href: engine/bug-bounties.md
   - name: Building source on Windows
     href: engine/building-source-windows.md

--- a/en/contributors/ways-to-contribute/code.md
+++ b/en/contributors/ways-to-contribute/code.md
@@ -18,8 +18,8 @@ For more information on how to get assigned to a project, how to fulfil a task a
 
 ## Important resources
 
-* **[🛠️ Contribute to the engine](../engine/index.md)** - contains all resources for contributing to the engine
-* **[🛠️ Contribute to the engine — 🏗️ Architecture](../engine/architecture/index.md)** - documentation related to the project architecture. It is also available in the [engine's repository](https://github.com/stride3d/stride/tree/master/docs) 
+* [🛠️ Contribute to the engine](../engine/index.md) - contains all resources for contributing to the engine
+* [🛠️ Contribute to the engine — 🏗️ Architecture](../engine/architecture/index.md) - documentation related to the project architecture. It is also available in the [engine's repository](https://github.com/stride3d/stride/tree/master/docs) 
 
 ## Community toolkit
 

--- a/en/contributors/ways-to-contribute/code.md
+++ b/en/contributors/ways-to-contribute/code.md
@@ -4,9 +4,7 @@ Stride is an open source project, meaning that **anyone can view and contribute 
 
 ## How to start contributing
 
-It's important to keep in mind when suggesting changes that Stride is a community project, meaning that **modifying crucial components to your liking may not be what others want**.
-
-When starting out, make sure to first **familiarize yourself with the architecture**. The best way to do that is to try tackling issues labeled [good first issue](https://github.com/stride3d/stride/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
+Stride is a very large project, which can make working with its code quite overwhelming when starting out. It's a lot easier to first try tackling issues labeled [good first issue](https://github.com/stride3d/stride/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22), which will help you **familiarize yourself with the engine's architecture**.
 
 ![](media/stride-repo-good-first-issue.webp)
 
@@ -16,7 +14,7 @@ If you are a developer with solid experience in C#, rendering techniques, or gam
 
 ![](media/open-collective.webp)
 
-For more information on how to get assigned to a project, how to fulfil a task and how to get paid, visit [🛠️ Contribute to the engine — Bug bounties](../engine/bug-bounties.md).
+For more information on how to get assigned to a project, how to fulfil a task and how to get paid, visit [🛠️ Contribute to the engine — Paid work](../engine/bug-bounties.md).
 
 ## Important resources
 

--- a/en/contributors/ways-to-contribute/code.md
+++ b/en/contributors/ways-to-contribute/code.md
@@ -1,0 +1,28 @@
+# Contribute code
+
+Stride is an open source project, meaning that **anyone can view and contribute to its code**. The source is hosted on GitHub
+
+## How to start contributing
+
+It's important to keep in mind when suggesting changes that Stride is a community project, meaning that **modifying crucial components to your liking may not be what others want**.
+
+When starting out, make sure to first **familiarize yourself with the architecture**. The best way to do that is to try tackling issues labeled [good first issue](https://github.com/stride3d/stride/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
+
+![](media/stride-repo-good-first-issue.webp)
+
+## Paid work
+
+If you are a developer with solid experience in C#, rendering techniques, or game development, **we want to hire you!** We have allocated funds from supporters on [OpenCollective](https://opencollective.com/stride3d) and **will pay you for your work on certain issues**.
+
+![](media/open-collective.webp)
+
+For more information on how to get assigned to a project, how to fulfil a task and how to get paid, visit [🛠️ Contribute to the engine — Bug bounties](../engine/bug-bounties.md).
+
+## Important resources
+
+* **[🛠️ Contribute to the engine](../engine/index.md)** - contains all resources for contributing to the engine
+* **[🛠️ Contribute to the engine — 🏗️ Architecture](../engine/architecture/index.md)** - documentation related to the project architecture. It is also available in the [engine's repository](https://github.com/stride3d/stride/tree/master/docs) 
+
+## Community toolkit
+
+The community toolkit provides helpers and extensions that enhance your experience with the engine and enable **code-only development**. For more information, visit the [contributing section in its documentation](https://stride3d.github.io/stride-community-toolkit/contributing/index.html).

--- a/en/contributors/ways-to-contribute/content.md
+++ b/en/contributors/ways-to-contribute/content.md
@@ -8,7 +8,7 @@ Our documentation is built using [docfx](https://dotnet.github.io/docfx/). All p
 
 Depending on the type of contribution, **you might not even have to download the repository in order to submit changes**. GitHub's file editor can suffice when fixing spelling errors, or adding a note to an existing page.
 
-For more information, visit our [📖 Contribute to the documentation](../documentation/index.md) section, which contains resources on how to create new pages, build the documentation and more.
+For more information, visit our [📖 Contribute to the documentation](../documentation/index.md) section, which contains resources on how to create new pages, build the documentation website and more.
 
 > [!TIP]
 > If you **don't know where to start**, try finding an [open issue labeled "good first issue"](https://github.com/stride3d/stride-docs/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
@@ -19,7 +19,7 @@ The Stride website is the landing place for all new users that would like to lea
 
 The website is built using [11ty](https://www.11ty.dev/) and [bootstrap](https://getbootstrap.com/). We keep our dependencies as minimal as possible to make it easier for other people to submit their own changes.
 
-For more information, visit out [🌐️ Contribute to the website](../website/index.md) section, which contains resources on how build the website, create new content and more.
+For more information, visit our [🌐️ Contribute to the website](../website/index.md) section, which contains resources on how build the website, create new content and more.
 
 > [!TIP]
 > If you **don't know where to start**, try finding an [open issue labeled "good first issue"](https://github.com/stride3d/stride-website/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).

--- a/en/contributors/ways-to-contribute/content.md
+++ b/en/contributors/ways-to-contribute/content.md
@@ -1,0 +1,27 @@
+# Contribute content
+
+There is a lot that goes into making an engine and code is only a part of it. Being an open source project, Stride's website and documentation source code is also available on GitHub under their respective repositories.
+
+TODO: IMAGE
+
+## Contributing to the documentation
+
+Our documentation is built using [docfx](https://dotnet.github.io/docfx/). All pages are written in [Markdown](https://en.wikipedia.org/wiki/Markdown), which is a file format **designed to be intuitive** even for people **not familiar with html and web development**.
+
+Depending on the type of contribution, **you might not even have to download the repository in order to submit changes**. GitHub's file editor can suffice when fixing spelling errors, or adding a note to an existing page.
+
+For more information, visit our [📖 Contribute to the documentation](../documentation/index.md) section, which contains resources on how to create new pages, build the documentation and more.
+
+> [!TIP]
+> If you **don't know where to start**, try finding an [open issue labeled "good first issue"](https://github.com/stride3d/stride-docs/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).
+
+## Contributing to the website
+
+The Stride website is the landing place for all new users that would like to learn more about the engine. It's important to keep it functional and up-to-date, as to not make a bad first impression.
+
+The website is built using [11ty](https://www.11ty.dev/) and [bootstrap](https://getbootstrap.com/). We keep our dependencies as minimal as possible to make it easier for other people to submit their own changes.
+
+For more information, visit out [🌐️ Contribute to the website](../website/index.md) section, which contains resources on how build the website, create new content and more.
+
+> [!TIP]
+> If you **don't know where to start**, try finding an [open issue labeled "good first issue"](https://github.com/stride3d/stride-website/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22).

--- a/en/contributors/ways-to-contribute/content.md
+++ b/en/contributors/ways-to-contribute/content.md
@@ -2,8 +2,6 @@
 
 There is a lot that goes into making an engine and code is only a part of it. Being an open source project, Stride's website and documentation source code is also available on GitHub under their respective repositories.
 
-TODO: IMAGE
-
 ## Contributing to the documentation
 
 Our documentation is built using [docfx](https://dotnet.github.io/docfx/). All pages are written in [Markdown](https://en.wikipedia.org/wiki/Markdown), which is a file format **designed to be intuitive** even for people **not familiar with html and web development**.

--- a/en/contributors/ways-to-contribute/content.md
+++ b/en/contributors/ways-to-contribute/content.md
@@ -17,7 +17,7 @@ For more information, visit our [📖 Contribute to the documentation](../docume
 
 The Stride website is the landing place for all new users that would like to learn more about the engine. It's important to keep it functional and up-to-date, as to not make a bad first impression.
 
-The website is built using [11ty](https://www.11ty.dev/) and [bootstrap](https://getbootstrap.com/). We keep our dependencies as minimal as possible to make it easier for other people to submit their own changes.
+The website is built using [11ty](https://www.11ty.dev/) and [Bootstrap](https://getbootstrap.com/). We keep our dependencies as minimal as possible to make it easier for other people to submit their own changes.
 
 For more information, visit our [🌐️ Contribute to the website](../website/index.md) section, which contains resources on how build the website, create new content and more.
 

--- a/en/contributors/ways-to-contribute/donate.md
+++ b/en/contributors/ways-to-contribute/donate.md
@@ -1,0 +1,18 @@
+# Donating to Stride
+
+In order to support our contributors or if we want to finance a specific feature, we collect donations from individuals as well as organisations. 
+
+## Open Collective
+
+We gather funding through a website called [OpenCollective](https://opencollective.com/stride3d). This website displays where all the money is coming from and where it is going to: 100% transparency guaranteed.
+
+![](media/open-collective.webp)
+
+## Projects
+
+Stride's Open Collective hosts different [Projects](https://opencollective.com/stride3d/projects), think of them as funding goals for specific features or contributions. Each project typically has a related GitHub ticket for more details on what's required for its development.
+
+If you're interested in working on or contributing to a particular feature, you can let us know by either replying:
+
+ - In each projects related GitHub thread and mention @stride3d/stride-contributors 
+ - In the Stride [Contributors channel on Discord](https://discord.gg/bDhMhGVHvD)

--- a/en/contributors/ways-to-contribute/donate.md
+++ b/en/contributors/ways-to-contribute/donate.md
@@ -12,7 +12,4 @@ We gather funding through a website called [OpenCollective](https://opencollecti
 
 Stride's Open Collective hosts different [Projects](https://opencollective.com/stride3d/projects), think of them as funding goals for specific features or contributions. Each project typically has a related GitHub ticket for more details on what's required for its development.
 
-If you're interested in working on or contributing to a particular feature, you can let us know by either replying:
-
- - In each projects related GitHub thread and mention @stride3d/stride-contributors 
- - In the Stride [Contributors channel on Discord](https://discord.gg/bDhMhGVHvD)
+If you're interested in working on or contributing to a particular feature, check out [🛠️ Contribute to the engine — Paid work](../engine/bug-bounties.md).

--- a/en/contributors/ways-to-contribute/index.md
+++ b/en/contributors/ways-to-contribute/index.md
@@ -1,0 +1,3 @@
+---
+redirect_url: ../index.md
+---

--- a/en/contributors/ways-to-contribute/media/open-collective-projects.webp
+++ b/en/contributors/ways-to-contribute/media/open-collective-projects.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce75039d0c8b747e803d4a369482a57a2af9385bc027d5bf52052a43e72ff8f0
+size 64172

--- a/en/contributors/ways-to-contribute/media/open-collective.webp
+++ b/en/contributors/ways-to-contribute/media/open-collective.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c898c54dc9855a076d491006fb37c62af93751096523c035e137c8c2f2f28a0
+size 61496

--- a/en/contributors/ways-to-contribute/media/stride-repo-good-first-issue.webp
+++ b/en/contributors/ways-to-contribute/media/stride-repo-good-first-issue.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f8841908e6c2ad445f84ba3807e726a5573a885153f32a47b47254d2e2f68b7
+size 85326


### PR DESCRIPTION
# Description

* Changes `ways to contribute` to use cards
* Creates separate pages for contributing code, content and donating
* Moves donate from root to `ways to contribute`
* Rewrites the index page of `contribute to the engine`
* Removes `engine/contribute to code` (because there is a different page named that now) and moves some information from it to the index page
* Changes name of `Bug bounties` page to `Paid work`.

# Motivation
Currently `Ways to contribute` is a giant list of different ways that are all treated on the same level. This can make users feel overwhelmed, or generally obstruct information.

# Specific changes

The new page now uses cards that outline the 3 main ways of contributing: money, code and content. Additional ways are listed below in a bullet-point list.

<img width="1350" height="1385" alt="image" src="https://github.com/user-attachments/assets/502fbeea-2f55-40ac-88d7-85d16740d55c" />

The `Ways to contribute` now has 3 sub-pages for each main way of contributing. Donate is relocated to the `ways to contribute` folder for consistency. Other pages are written from scratch.

<img width="241" height="144" alt="image" src="https://github.com/user-attachments/assets/0db556b2-68a7-4755-bd71-7a0cc6baf2ae" />

Because the index page of the contributing tab is now a section, there is an index for `ways of contribute` that just redirects to the contributing index, in case someone tries to navigate the docs by changing the url directly (which is something that at least I tend to do).

Now getting to the `engine` section. The `Contribute to code` page has been removed, so that the `ways to contribute/contribute code` can take its place. The removed page's content has been moved to the index.

<img width="1300" height="1369" alt="image" src="https://github.com/user-attachments/assets/255367db-669d-4295-ada2-90dede5193ae" />

The index page has been overhauled from the ground up, removing header links and adding information about how to contribute, highlighting `paid work`, coding style, mentioning architecture documentation and providing additional information to hopefully improve navigation.

# To discuss
1. I renamed `Bug bounties` to `Paid work`, because open collective contains more than just bug bounties. It made it slightly misleading, but it may have also made it easier to find (bug bounties is a commonly used term that's easily recognizable). Maybe it should be changed back to what it was, or maybe `Paid work (bug bounties)`/`Bug bounties (paid work)`?
2. Donation page has been moved for consistency, but maybe it should be back where it was to not clutter the files with additional redirect pages?