### PR TITLE
Corrected a few pages

### DIFF
--- a/en/includes/cli-manage-versions-commands.md
+++ b/en/includes/cli-manage-versions-commands.md
@@ -1,0 +1,15 @@
+| Command | Description |
+| :-- | :-- |
+| `stride sdk install` | Install the latest version of the engine or the resolved project's version located in the current directory. |
+| `stride sdk install VERSION` | Install a specific version of the engine. Version patch number is optional. |
+| `stride sdk available` | List available versions of the engine. |
+| `stride sdk list` | List all installed versions. |
+| `stride sdk update` | Update all installed versions of the engine to the latest patch. |
+| `stride sdk update VERSION` | Update a specific installed version of the engine to the latest patch. Version patch number is optional. |
+| `stride sdk uninstall VERSION` | Uninstall a specific version of the engine. |
+
+> [!NOTE]
+> For many commands, the patch version can be skipped (e.g. `4.3`).
+
+> [!TIP]
+> The CLI will ignore beta versions of the engine, unless you pass the `--prerelease` flag.

--- a/en/includes/cli-manage-versions-commands.md
+++ b/en/includes/cli-manage-versions-commands.md
@@ -1,3 +1,10 @@
+```bash
+stride sdk available --prerelease # List all available versions, including betas
+stride sdk install # Install the latest version
+stride sdk update # Update all installed versions to the latest patch.
+stride sdk uninstall 4.3 # Unintall Stride 4.3
+```
+
 | Command | Description |
 | :-- | :-- |
 | `stride sdk install` | Install the latest version of the engine or the resolved project's version located in the current directory. |

--- a/en/includes/cli-new-project-parameters.md
+++ b/en/includes/cli-new-project-parameters.md
@@ -1,0 +1,27 @@
+All Stride templates can take additional parameters to change how they are created. Here's a list of the most commonly used ones:
+
+| Parameter | Values | Description |
+| :-- | :-- | :-- |
+| `-n` | text | Name of the project. |
+| `--platform` | `host` (the current os), `window`, `linux`, `macos`, `android`, `ios` | Platform(s) the project should target, separated by the `|` character. |
+| `--HDR` | `true`, `false` | Determines if the project uses HDR (required graphics profile >= 10.0). |
+| `--graphics-profile` | `9.0`, `10.0`, `11.0` | The graphics profile to use. This can be changed later. |
+| `--orientation` | `Default`, `LandscapeLeft`, `LandscapeRight`, `Portrait` | The game's orientation on mobile devices. This can be changed later. |
+
+For a list of all available parameters in a template, use the `--help` flag.
+
+Example command:
+
+### [Powershell (Windows)](#tab/powershell)
+
+```powershell
+stride new game -n ProjectX --HDR true --platform windows`|linux
+```
+
+### [Bash (Linux)](#tab/bash)
+
+```bash
+stride new game -n ProjectX --HDR true --platform windows\|linux
+```
+
+---

--- a/en/manual/get-started/create-a-project.md
+++ b/en/manual/get-started/create-a-project.md
@@ -81,6 +81,10 @@ The Stride CLI tool provides a way of creating new projects without the need for
     stride studio ./ProjectNameHere
     ````
 
+### Template parameters
+
+[!INCLUDE [cli-new-project-parameters](../../includes/cli-new-project-parameters.md)]
+
 ## Create a project with dotnet templates
 
 An alternative way of creating a project from the command line without the need for Stride CLI is to use **dotnet templates**.
@@ -110,32 +114,5 @@ An alternative way of creating a project from the command line without the need 
 
 4. Open **Game Studio** manually.
 
-## Command line template parameters
-
-All Stride templates can take additional parameters to change how they are created. Here's a list of the most commonly used ones:
-
-| Parameter | Values | Description |
-| :-- | :-- | :-- |
-| `-n` | text | Name of the project. |
-| `--platform` | `host` (the current os), `window`, `linux`, `macos`, `android`, `ios` | Platform(s) the project should target, separated by the `|` character. |
-| `--HDR` | `true`, `false` | Determines if the project uses HDR (required graphics profile >= 10.0). |
-| `--graphics-profile` | `9.0`, `10.0`, `11.0` | The graphics profile to use. This can be changed later. |
-| `--orientation` | `Default`, `LandscapeLeft`, `LandscapeRight`, `Portrait` | The game's orientation on mobile devices. This can be changed later. |
-
-For a list of all available parameters in a template, use the `--help` flag.
-
-Example command:
-
-### [Powershell (Windows)](#tab/powershell)
-
-```powershell
-stride new game -n ProjectX --HDR true --platform windows`|linux
-```
-
-### [Bash (Linux)](#tab/bash)
-
-```bash
-stride new game -n ProjectX --HDR true --platform windows\|linux
-```
-
----
+> [!WARNING]
+> Due to their size, most examples and templates are only updated with minor and major releases. This means that **you will have to upgrade them manually to ensure they are on the latest version**. This is automatically handled when opening the project via the launcher.

--- a/en/manual/get-started/stride-cli.md
+++ b/en/manual/get-started/stride-cli.md
@@ -44,7 +44,7 @@ stride
 | Command | Description |
 | :-- | :-- |
 | `stride sdk` | Manage installed Stride versions (list, available, install, uninstall, update). For more information, visit the [Manage versions](#manage-versions) section. |
-| `stride new` | Create a project from an installed Stride version's templates. For more information, read [Create a project — Create a project with Stride CLI](create-a-project.md#create-a-project-with-stride-cli). |
+| `stride new` | Create a project from an installed Stride version's templates. For more information, visit the [Create a new project](#create-a-new-project) section. |
 | `stride upgrade` | Upgrade a project to a newer installed Stride version. For more information, read [Update Stride — Updating your project with Stride CLI](../install-and-update/update-stride.md#updating-your-project-with-stride-cli). |
 | `stride studio` | Open Game Studio. |
 | `stride self` | Manage the Stride CLI itself. |
@@ -69,7 +69,9 @@ dotnet run --project ProjectX.Windows # Build and run the project
 stride studio # Open Game Studio
 ```
 
-For more information, visit [Create a project — Create a project with Stride CLI](create-a-project.md#create-a-project-with-stride-cli).
+[!INCLUDE [cli-new-project-parameters](../../includes/cli-new-project-parameters.md)]
+
+For more detailed instructions, visit [Create a project — Create a project with Stride CLI](create-a-project.md#create-a-project-with-stride-cli).
 
 ### Manage versions
 

--- a/en/manual/get-started/stride-cli.md
+++ b/en/manual/get-started/stride-cli.md
@@ -81,21 +81,7 @@ stride sdk update # Update all installed versions to the latest patch.
 stride sdk uninstall 4.3 # Unintall Stride 4.3
 ```
 
-| Command | Description |
-| :-- | :-- |
-| `stride sdk install` | Install the latest version of the engine or the resolved project's version located in the current directory. |
-| `stride sdk install VERSION` | Install a specific version of the engine. Version patch number is optional. |
-| `stride sdk available` | List available versions of the engine. |
-| `stride sdk list` | List all installed versions. |
-| `stride sdk update` | Update all installed versions of the engine to the latest patch. |
-| `stride sdk update VERSION` | Update a specific installed version of the engine to the latest patch. Version patch number is optional. |
-| `stride sdk uninstall VERSION` | Uninstall a specific version of the engine. |
-
-> [!NOTE]
-> For many commands, the patch version can be skipped (e.g. `4.3`).
-
-> [!TIP]
-> The CLI will ignore beta versions of the engine, unless you pass the `--prerelease` flag.
+[!INCLUDE [cli-manage-versions-command](../../includes/cli-manage-versions-commands.md)]
 
 ### Upgrade project to a newer version
 

--- a/en/manual/get-started/stride-cli.md
+++ b/en/manual/get-started/stride-cli.md
@@ -43,7 +43,7 @@ stride
 
 | Command | Description |
 | :-- | :-- |
-| `stride sdk` | Manage installed Stride versions (list, available, install, uninstall, update). For more information, read [Manage versions — Managing versions with Stride CLI](../install-and-update/manage-versions.md#managing-versions-with-stride-cli). |
+| `stride sdk` | Manage installed Stride versions (list, available, install, uninstall, update). For more information, visit the [Manage versions](#manage-versions) section. |
 | `stride new` | Create a project from an installed Stride version's templates. For more information, read [Create a project — Create a project with Stride CLI](create-a-project.md#create-a-project-with-stride-cli). |
 | `stride upgrade` | Upgrade a project to a newer installed Stride version. For more information, read [Update Stride — Updating your project with Stride CLI](../install-and-update/update-stride.md#updating-your-project-with-stride-cli). |
 | `stride studio` | Open Game Studio. |
@@ -58,7 +58,9 @@ For more information about how to use a given command, use the `--help` flag. Fo
 stride sdk --help
 ```
 
-## Example usage
+### Create a new project
+
+Here's an example on how to create a new project on the latest version of the engine using the CLI.
 
 ```bash
 stride sdk install # Install the latest version
@@ -66,6 +68,46 @@ stride new game -n ProjectX && cd ProjectX # Create a new project and enter it's
 dotnet run --project ProjectX.Windows # Build and run the project
 stride studio # Open Game Studio
 ```
+
+For more information, visit [Create a project — Create a project with Stride CLI](create-a-project.md#create-a-project-with-stride-cli).
+
+### Manage versions
+
+As mentioned previously, Stride CLI let's you do everything you could do with the launcher directly through the command line.
+
+```bash
+stride sdk install # Install the latest version
+stride sdk update # Update all installed versions to the latest patch.
+stride sdk uninstall 4.3 # Unintall Stride 4.3
+```
+
+| Command | Description |
+| :-- | :-- |
+| `stride sdk install` | Install the latest version of the engine or the resolved project's version located in the current directory. |
+| `stride sdk install VERSION` | Install a specific version of the engine. Version patch number is optional. |
+| `stride sdk available` | List available versions of the engine. |
+| `stride sdk list` | List all installed versions. |
+| `stride sdk update` | Update all installed versions of the engine to the latest patch. |
+| `stride sdk update VERSION` | Update a specific installed version of the engine to the latest patch. Version patch number is optional. |
+| `stride sdk uninstall VERSION` | Uninstall a specific version of the engine. |
+
+> [!NOTE]
+> For many commands, the patch version can be skipped (e.g. `4.3`).
+
+> [!TIP]
+> The CLI will ignore beta versions of the engine, unless you pass the `--prerelease` flag.
+
+### Upgrade project to a newer version
+
+The CLI can upgrade projects similarly to Game Studio. On top of changing the engine version, it will use additional utilities to modify assets and code, to ensure everything works properly.
+
+```bash
+stride upgrade # Upgrade the project to the latest version
+stride upgrade --prerelease # Consider beta versions
+stride upgrade 4.3 # Upgrade the project to 4.3
+```
+
+For more information visit [Update Stride — Updating your project with Stride CLI](../install-and-update/update-stride.md#updating-your-project-with-stride-cli).
 
 ## See also
 

--- a/en/manual/get-started/stride-cli.md
+++ b/en/manual/get-started/stride-cli.md
@@ -77,12 +77,6 @@ For more detailed instructions, visit [Create a project — Create a project wit
 
 As mentioned previously, Stride CLI let's you do everything you could do with the launcher directly through the command line.
 
-```bash
-stride sdk install # Install the latest version
-stride sdk update # Update all installed versions to the latest patch.
-stride sdk uninstall 4.3 # Unintall Stride 4.3
-```
-
 [!INCLUDE [cli-manage-versions-command](../../includes/cli-manage-versions-commands.md)]
 
 ### Upgrade project to a newer version

--- a/en/manual/get-started/visual-studio-extension.md
+++ b/en/manual/get-started/visual-studio-extension.md
@@ -2,7 +2,7 @@
 
 <span class="badge text-bg-primary">Beginner</span>
 
-The **Stride extension** is an **optional** extension for IDEs that provides utilities for working with Stride.
+The **Stride extension** is an **optional** extension for IDEs that provides syntax highlighting for SDSL shaders and utilities for working with Stride.
 
 It isn't needed for syntax highlighting in C#.
 
@@ -34,11 +34,14 @@ The extension can be installed from [open-vsx](https://open-vsx.org/extension/te
 
 The Stride Extension for Visual Studio Code / VSCodium is a community project that provides **different functionality** compared to the official Visual Studio extension. 
 
-| Visual Studio | Visual Studio Code / VSCodium |
-| :-- | :-- |
-| Official | Community project |
-| Provides Stride-related utilities | Provides tools for shader development |
-| Open Source ([repository link](https://github.com/stride3d/stride)) | Open Source ([repository link](https://github.com/tebjan/Stride.ShaderExplorer)) |
+| | Visual Studio | Visual Studio Code / VSCodium |
+| :-- | :-: | :-: |
+| Type | Official | Community project |
+| Shader syntax highlighting | 🟩 | 🟩 |
+| Stride-related utilities | 🟩 | 🟥 |
+| Extra shader development tools | 🟥 | 🟩 |
+| Open source | 🟩 | 🟩 |
+| Repository link | [here](https://github.com/stride3d/stride) | [here](https://github.com/tebjan/Stride.ShaderExplorer) |
 
 ## Opening Game Studio from your IDE
 

--- a/en/manual/install-and-update/install-stride.md
+++ b/en/manual/install-and-update/install-stride.md
@@ -45,7 +45,7 @@ Changing the installation location is possible, but explaining this is outside o
 
 Stride has an optional extension that's available for some IDEs.
 
-- **🟩 What it does**: provides useful utilities related to the engine.
+- **🟩 What it does**: provides shader syntax highlighting useful utilities related to the engine.
 - **🟥 What it doesn't do**: provide C# syntax highlighting for Stride (that works without the extension).
 
 The extension can be installed for Visual Studio via the launcher, by navigating to the **Visual Studio extension** section. For other IDEs, visit the [Stride Extension page](../get-started/visual-studio-extension.md).

--- a/en/manual/install-and-update/manage-versions.md
+++ b/en/manual/install-and-update/manage-versions.md
@@ -39,7 +39,7 @@ To remove a specific installed version of the engine:
 
 ## Managing versions with Stride CLI
 
-The **Stride CLI** let's you install, uninstall and update versions of the engine directly through the command line.
+The **Stride CLI** let's you install, uninstall and update versions of the engine directly through the command line. For steps on how to install it, read [Stride CLI](../get-started/stride-cli.md).
 
 ```bash
 stride sdk install # Install the latest version
@@ -47,4 +47,4 @@ stride sdk update # Update all installed versions to the latest patch.
 stride sdk uninstall 4.3 # Unintall Stride 4.3
 ```
 
-For more information about how to install and use the CLI tool, visit [Stride CLI](../get-started/stride-cli.md).
+[!INCLUDE [cli-manage-versions-command](../../includes/cli-manage-versions-commands.md)]

--- a/en/manual/install-and-update/manage-versions.md
+++ b/en/manual/install-and-update/manage-versions.md
@@ -39,18 +39,12 @@ To remove a specific installed version of the engine:
 
 ## Managing versions with Stride CLI
 
-The **Stride CLI** let's you install, uninstall and update versions of the engine directly through the command line. For steps on how to install it, read [Stride CLI](../get-started/stride-cli.md).
+The **Stride CLI** let's you install, uninstall and update versions of the engine directly through the command line.
 
-| Command | Description |
-| :-- | :-- |
-| `stride sdk install` | Install the latest version of the engine or the resolved project's version located in the current directory. |
-| `stride sdk install VERSION` | Install a specific version of the engine. Version patch number is optional. |
-| `stride sdk available` | List available versions of the engine. |
-| `stride sdk list` | List all installed versions. |
-| `stride sdk update` | Update all installed versions of the engine to the latest patch. |
-| `stride sdk update VERSION` | Update a specific installed version of the engine to the latest patch. Version patch number is optional. |
-| `stride sdk uninstall VERSION` | Uninstall a specific version of the engine. |
-| `stride studio` | Launch Game Studio. |
+```bash
+stride sdk install # Install the latest version
+stride sdk update # Update all installed versions to the latest patch.
+stride sdk uninstall 4.3 # Unintall Stride 4.3
+```
 
-> [!NOTE]
-> For many commands, the patch version can be skipped (e.g. `4.3`).
+For more information about how to install and use the CLI tool, visit [Stride CLI](../get-started/stride-cli.md).

--- a/en/manual/install-and-update/manage-versions.md
+++ b/en/manual/install-and-update/manage-versions.md
@@ -41,10 +41,4 @@ To remove a specific installed version of the engine:
 
 The **Stride CLI** let's you install, uninstall and update versions of the engine directly through the command line. For steps on how to install it, read [Stride CLI](../get-started/stride-cli.md).
 
-```bash
-stride sdk install # Install the latest version
-stride sdk update # Update all installed versions to the latest patch.
-stride sdk uninstall 4.3 # Unintall Stride 4.3
-```
-
 [!INCLUDE [cli-manage-versions-command](../../includes/cli-manage-versions-commands.md)]

--- a/en/manual/install-and-update/manage-versions.md
+++ b/en/manual/install-and-update/manage-versions.md
@@ -43,7 +43,7 @@ The **Stride CLI** let's you install, uninstall and update versions of the engin
 
 | Command | Description |
 | :-- | :-- |
-| `stride sdk install` | Install the latest version of the engine. |
+| `stride sdk install` | Install the latest version of the engine or the resolved project's version located in the current directory. |
 | `stride sdk install VERSION` | Install a specific version of the engine. Version patch number is optional. |
 | `stride sdk available` | List available versions of the engine. |
 | `stride sdk list` | List all installed versions. |


### PR DESCRIPTION
Corrects a few pages:
* Adds a warning to the dotnet templates section of `Create a project`
* Updated the extension description to specify that it provides SDSL syntax highlighting on `Stride Extension` and `Install Stride`
* Improvements to the VS vs VSCode comparison chart in `Stride Extension`
* Adds command table from cli section of `Manage versions` to `Stride CLI`
* Adds parameters list from cli section of `Create a project` to `Stride CLI`
* Adds more examples to `Stride CLI`