### PR TITLE
Updated release notes

### DIFF
--- a/en/ReleaseNotes/ReleaseNotes.md
+++ b/en/ReleaseNotes/ReleaseNotes.md
@@ -8,6 +8,8 @@ a new CLI tool providing an alternative to some of Game Studio's functions.
 
 ## ✨ Highlights
 
+Here are a few of the stand-out changes:
+
 ### 📱 Platform support
 
 Stride 4.4 widens both where you can *build* games and where they *run*.

--- a/en/ReleaseNotes/ReleaseNotes.md
+++ b/en/ReleaseNotes/ReleaseNotes.md
@@ -1,44 +1,32 @@
 # Stride 4.4 release notes
 
-Stride 4.4 is one of the largest engine updates in years, with roughly **2,400 commits** since 4.3.
+Stride 4.4 is one of the largest engine updates in years, with roughly **2400 commits** since 4.3.
 
-The theme of this release is **modernization and reach**: much more stable **Vulkan and Direct3D 12** backends,
-full platform coverage across **Windows, Linux, macOS, Android and iOS** (all continuously tested on CI),
-an improved shader compiler, and a command-line workflow as an alternative to the Game Studio.
+The focus of this release is on **modernization and reach**, with much more stable **Vulkan** and **Direct3D 12** backends,
+full platform coverage across **Windows**, **Linux**, **macOS**, **Android** and **iOS** (all continuously tested on CI), an improved shader compiler and
+a new CLI tool providing an alternative to some of Game Studio's functions.
 
 ## ✨ Highlights
 
-### 📱 Platforms & Cross-Platform
+### 📱 Platform support
 
 Stride 4.4 widens both where you can *build* games and where they *run*.
 
-**Build anywhere:** with changes to the asset compiler, projects can now be built on **Linux and macOS**, not just Windows.
+**Build anywhere:** with changes to the asset compiler, projects can now be built on **Linux** and **macOS**, not just Windows.
 
 **Run everywhere:** non-Windows platforms were brought back into shape, while the test suite for them was expanded to ensure they are kept that way.
 
-![A Stride sample running on a physical iPhone](media/ReleaseNotes-4.4/ios.jpg)
+![A Stride sample running on a physical iPhone](media/ReleaseNotes-4.4/ios.webp)
 
-### ⌨️ A command-line workflow: the `stride` CLI + `dotnet new` templates
+### ⌨️ A command-line workflow: Stride CLI + `dotnet new` templates
 
-You can now create, build and run Stride games entirely from the command line, with no Game Studio install required.
-
-| Command                                       | Purpose                                                                                        |
-|-----------------------------------------------|------------------------------------------------------------------------------------------------|
-| `stride new`                                  | instantiate a project from installed templates in this directory (`stride new list` to browse) |
-| `stride build` / `stride asset`               | build the project and compile assets                                                           |
-| `stride upgrade`                              | upgrade a project to a newer Stride version                                                    |
-| `stride studio`                               | launch the Game Studio associated with the Stride version you use for this project             |
-| `stride sdk install` / `uninstall` / `update` | manage installed Stride versions                                                               |
-| `stride self update`                          | update the CLI itself                                                                          |
-| `stride version`                              | print the CLI's version, as well as the Stride version for this project                        |
-
-You'll need to install the Stride CLI through `dotnet tool` if you want to use this new feature:
+You can now create, build and run Stride games entirely from the command line, with no Game Studio install required thanks to our new cli tool. For more information on how to install and use it, visit the [Stride CLI](../manual/get-started/stride-cli.md) page of our documentation.
 
 ```bash
-dotnet tool install -g stride.cli                 # install the Stride CLI
-stride sdk install                                # install the latest Stride
-stride new topdownrpg && cd TopDownRPG            # create a project from a template
-stride studio                                     # open it in Game Studio
+dotnet tool install -g stride.cli      # install the Stride CLI
+stride sdk install                     # install the latest Stride
+stride new topdownrpg && cd TopDownRPG # create a project from a template
+stride studio                          # open it in Game Studio
 ```
 
 `dotnet new` templates are also available as a lightweight fallback if you'd rather use the standard .NET tooling directly:
@@ -50,114 +38,122 @@ dotnet new stride-game -n MyGame
 
 ### 🎮 Vulkan & Direct3D 12
 
-Both backends got a big **overhaul and stability pass** this cycle and are in much better shape.
-They're now solid enough that we expect to make a modern backend the editor default before long,
-and **Direct3D 11 is a candidate for removal in the next major release**.
-GPU crashes are also far easier to track down: Stride can now pinpoint the exact rendering step that caused a device hang.
+Both backends got a big **overhaul and stability pass** and are in a much better shape. They're now solid enough that we expect to make a modern backend the editor default before long and **Direct3D 11 is a candidate for removal in the next major release**. GPU crashes are also far easier to track down: Stride can now pinpoint the exact rendering step that caused a device hang.
 
-If you write custom low-level rendering code,
-note that D3D12 and Vulkan now use an **explicit barrier/layout model** (and D3D12 requires **Enhanced Barriers** — the legacy path was removed).
+> [!NOTE]
+> If you write custom low-level rendering code, note that D3D12 and Vulkan now use an **explicit barrier/layout model** (and D3D12 requires **Enhanced Barriers** — the legacy path was removed).
 
-You can also pick the graphics API right from the UI now.
-Game Studio itself can render with a chosen backend via **Settings → Environment → Graphics API (Game Studio only)** — this takes effect after a restart:
+Also, you can now pick the graphics API right from the UI for both your project and the editor. Game Studio can be configured in **Settings > Environment > Graphics API** (takes effect after a restart) and the game in the properties of the Windows package.
 
-![Choosing the Game Studio graphics API in Settings → Environment](media/ReleaseNotes-4.4/gamestudio-graphics-api-selector.png)
-
-And each Windows game project can select its own **Graphics API** from the package build settings in the property grid:
-
-![Selecting a Windows project's graphics API from the property grid](media/ReleaseNotes-4.4/game-graphics-api-selector.png)
+![Selecting a Windows project package's graphics API from the Property grid](media/ReleaseNotes-4.4/game-graphics-api-selector.webp)
 
 ### 🎨 A brand-new SDSL shader compiler
 
-The biggest *internal* change in 4.4 is a **complete rewrite of the SDSL shader compiler**, now built around a modern **SPIR-V**-centric pipeline.
+The biggest internal change in 4.4 is a **complete rewrite of the SDSL shader compiler**, now built around a modern **SPIR-V**-centric pipeline.
 
 Instead of parsing and stitching shaders together as text, Stride now works in **SPIR-V bytecode** end to end:
 
-- Each `.sdsl` shader is parsed **once** and compiled into its own **SPIR-S** module (SPIR-Stride, Stride's extended SPIR-V dialect).
-- Effects (`.sdfx`) then **mix and compose** those modules **directly as bytecode**, lowering the result to standard **SPIR-V** for the GPU backend.
-- Crucially, text parsing happens **only at that first step**: recombining a new shader variation from already-compiled SPIR-S needs no re-parsing.
+* Each `.sdsl` shader is parsed **once** and compiled into its own **SPIR-S** module (SPIR-Stride, Stride's extended SPIR-V dialect).
+* Effects (`.sdfx`) then **mix and compose** those modules **directly as bytecode**, converting the result to standard **SPIR-V** for the GPU backend.
+* Crucially, text parsing happens **only at that first step**: recombining a new shader variation from already-compiled SPIR-S needs no re-parsing.
 
 What this means for you:
 
-- **Much faster shader handling.** Generating the many shader permutations a real game needs no longer touches a text parser; variations are recombined straight from cached bytecode.
-- **Built on mature, standard tooling.** **Vulkan** consumes the SPIR-V natively, while **Direct3D 11/12** and **Metal** reuse **SPIRV-Cross** (to HLSL/MSL), battle-tested components instead of a bespoke translator.
-- **Far better support for advanced features.** Direct3D 12 and Vulkan now handle things like **tessellation and compute shaders** much more reliably.
-- **A future-proof foundation.** With a real SPIR-V pipeline in place, adding modern GPU features such as **ray tracing, mesh shaders/meshlets and wave intrinsics** becomes much easier going forward.
+* **Much faster shader handling.** Generating the many shader permutations a real game needs no longer touches a text parser (variations are recombined straight from cached bytecode).
+* **Built on mature, standard tooling.** **Vulkan** consumes **SPIR-V** natively, while **Direct3D 11/12** and **Metal** reuse **SPIRV-Cross** (which converts SPIR-V to HLSL/MSL). These components are battle-tested and less likely to cause issues.
+* **Far better support for advanced features.** Direct3D 12 and Vulkan now handle things like **tessellation** and **compute shaders** much more reliably.
+* **A future-proof foundation.** With a real SPIR-V pipeline in place, adding modern GPU features such as **ray tracing**, **mesh shaders/meshlets** and **wave intrinsics** becomes much easier going forward.
 
-> [!Warning]
-> Because the entire shader compiler was replaced, custom `.sdsl` shaders may need minor adjustments to compile cleanly. If you maintain shaders, give them a pass on 4.4. See *Upgrade Notes* below.
+> [!WARNING]
+> Because the entire shader compiler was replaced, custom `.sdsl` shaders may need minor adjustments to compile cleanly. If you encounter any problems, please [open an issue on GitHub](https://github.com/stride3d/stride/issues) so we can fix it.
 
 ![The new SDSL shader pipeline: many .sdsl shaders are parsed once into per-shader SPIR-S bytecode, .sdfx effects mix and compose them into standard SPIR-V, which feeds Vulkan natively and Direct3D and Metal via SPIRV-Cross](media/ReleaseNotes-4.4/sdsl-pipeline.svg)
 
 *Huge thanks to **[Youness Kafia](https://github.com/ykafia)**, whose early prototyping and experimentation laid the foundation for the new SDSL pipeline.*
 
-### ⚡ NativeAOT & Trimming Support
+### ⚡ NativeAOT & trimming support
 
-The engine is now **NativeAOT and trimming-friendly**. This unlocks smaller, faster-starting, self-contained game builds.
+The engine is now **NativeAOT and trimming-friendly**. This unlocks smaller, faster-starting, self-contained game builds. For more information on how to use this, visit our [documentation](../manual/files-and-folders/building-the-game/native-aot.md).
 
-## 🛠 Engine & Graphics
+### 📦 Improved assets and content workflow
 
-- **Video subsystem rewrite:** a fresh Windows Media Foundation backend, plus a new AVFoundation backend on macOS.
-- **Direct3D 11 stability & correctness fixes.**
-- **Fonts:** upgraded to **FreeType 2.13**.
-- **Model importing:** upgraded to **Assimp 6**.
+Stride 4.4 makes it easier to work with assets through code thanks to the automatically generated `Assets` class, which provides strongly typed URL constants for all assets in your project. Now when you rename an asset, you will get build errors instead of a "content not found" message during runtime.
 
-## 🧰 Build, Tooling & Project System
+```csharp
+// Old approach
+var playerModel = Content.Load<Model>("Models/Player");
 
-- **Much faster asset builds.** Warm asset compiles drop by around **40%** for a typical game, and up to **10×** for Stride's own tests, thanks to a new asset-build cache.
-- **`.slnx` is the new default solution format** for projects created by Stride. Existing `.sln` solutions still open and save normally.
-- **Per-package asset URLs & namespacing.** Assets now live under a rooted, per-package path (e.g. `/MyGame/UI/Title`), so plugins and libraries can ship assets without name collisions. Games stay bare by default and opt in via `StrideAssetNamespace`, so existing projects keep working unchanged.
-- **Typed asset URL constants.** Projects now generate an `Assets` class of strongly-typed constants (e.g. `Assets.Scenes.MainScene`), so you can reference content by an IDE-completed symbol instead of a magic string. Renames then become compile errors instead of a runtime "content not found".
+// New approach
+var playerModel = Content.Load(Assets.Models.Player);
+```
 
-## 🧪 Quality & CI
+**Asset paths from external packages now begin with a namespace**, to ensure there are no conflicts between different libraries. This won't break your existing projects, as the paths will be **automatically changed in your code during the upgrade**.
 
-*Mostly under the hood — but it directly changes how confidently you can contribute back to the engine.*
+Additionally, Stride now allows you to create **replacement assets**, which can be used to override assets from external packages or even the engine itself. For more information, visit their dedicated page in the [documentation](../manual/assets/replacement-assets.md).
 
-Stride 4.4's test suite has been greatly expanded. Where earlier versions only exercised a slice of platforms,
-**every change now runs the entire test matrix** in one pipeline — engine builds, game and Game Studio tests,
-and end-to-end sample/packaging builds, across all platforms and graphics APIs,
-including **GPU image-comparison tests** (Windows D3D11/12, Linux Vulkan, macOS, Android, iOS):
+![Replacement assets can be used to override the default font used by Stride](media/ReleaseNotes-4.4/replacement-assets.webp)
 
-![The CI pipeline: a single run building and testing every platform and graphics API (Windows D3D11/D3D12/Vulkan, Linux, macOS, Android, iOS), all green](media/ReleaseNotes-4.4/ci-run.png)
+### 🧰 Build, tooling & project system
 
-Breakage on any platform or backend is now caught automatically before it reaches a release.
-For contributors, that's the real win: you can open a pull request and **trust CI to prove it works everywhere**,
-instead of testing each platform by hand — which makes contributing a feature back to the engine far less daunting.
+* **Much faster asset builds.** Assets compile **2x** faster for a typical game, and up to **10×** faster for Stride's own tests, thanks to a new asset-build cache.
+* **`.slnx` is the new default solution format** for projects created by Stride. Existing `.sln` solutions still open and save normally.
+* **Dropped support for 32-bit.** The engine now only targets modern 64-bit systems.
 
-A **gold-image generation workflow** runs **directly on CI**, so you no longer have to regenerate reference images by hand on every platform.
-Golds are produced and promoted straight from [the CI workflow](https://github.com/stride3d/stride/actions/workflows/test-gold-gen.yml).
+### ⚙️ Changes to the physics `CharacterComponent`
 
-The new **CompareGold** tool makes reviewing these tests painless — visually diff failures against their gold images,
-promote the ones you accept, and even pull results **directly from any CI run** or fork (see [GPU-TESTING.md](https://github.com/stride3d/stride/blob/master/tests/GPU-TESTING.md)).
+While our integration of the Bepu physics engine is definitely mature enough by now, the `CharacterComponent` we introduced was not as well put together as it ought to have been.
 
-![CompareGold reviewing image differences and promoting gold images](media/ReleaseNotes-4.4/compare-gold.png)
+* The gravity you may set would be mutated internally to prevent the body from sliding down slopes.
+* Moving surfaces would not carry the character along with them.
+* Moving past a slope would cause the character to fly off.
+* Forces applied to bodies, and especially constraints, required unintuitive tweaks to work.
 
-## ⚙️ Physics Character
+We looked at Bepu's own character example to solve these issues. Unfortunately, we could not avoid introducing a fair amount of breaking changes. *Fortunately*, we added a couple of sections in [Characters](../manual/physics/characters.md) to describe the new features and properties.
 
-While our integration of the Bepu physics engine is definitely mature enough by now,
-the `CharacterComponent` we introduced was not as well put together as it ought to have been.
+### 📖 Documentation
 
-- The gravity you may set would be mutated internally to prevent the body from sliding down slopes.
-- Moving surfaces would not carry the character along with them.
-- Moving past a slope would cause the character to fly off.
-- Forces applied to bodies, and especially constraints, required unintuitive tweaks to work.
+Since 4.3, our documentation has received a lot of changes. This is a part of an **ongoing effort to bring the documentation up-to-date** and restructure it to provide space for future content.
 
-We looked at Bepu's own character example to solve these issues; unfortunately, we could not avoid introducing a fair amount of breaking changes.
-Fortunately, we added a couple of sections in [Characters](../manual/physics/characters.md) to describe the new features and properties.
+![Documentation changelog is available in the manual](media/ReleaseNotes-4.4/docs.webp)
+
+* [Get started](../manual/get-started/index.md) and [Platforms](../manual/platforms/index.md) have been **rewritten from scratch**.
+* **New sections:** [Assets](../manual/assets/index.md), [Install and update](../manual/install-and-update/index.md) and [Project](../manual/files-and-folders/index.md).
+* **New pages for new features:** [NativeAOT](../manual/files-and-folders/building-the-game/native-aot.md), [Replacement assets](../manual/assets/replacement-assets.md) and [Stride CLI](../manual/get-started/stride-cli.md?tabs=powershell).
+* Brand new guide on **how to build and publish games** ([link](../manual/files-and-folders/building-the-game/index.md)).
+* Updated instructions on **publishing custom external packages** ([link](../manual/files-and-folders/external-packages/publish-a-nuget-package.md)).
+* Removed outdated sections and pages.
+
+We have also started documenting parts of Stride's internal architecture in the main [engine repository](https://github.com/stride3d/stride/tree/master/docs) to help other contributors navigate this large codebase. A copy of these pages is available on the [documentation website](../contributors/engine/architecture/index.md).
+
+### 🧪 Quality & CI
+
+*Mostly under the hood, but it directly changes how confidently you can contribute back to the engine.*
+
+Stride 4.4's test suite has been greatly expanded. Where earlier versions used to only be invoked on a slice of possible configurations, **every change now runs the entire test matrix across all platforms and graphics APIs in one pipeline:** engine builds, game and Game Studio tests, end-to-end sample/packaging builds and **GPU image-comparison**.
+
+![The CI pipeline: a single run building and testing every platform and graphics API (Windows D3D11/D3D12/Vulkan, Linux, macOS, Android, iOS), all green](media/ReleaseNotes-4.4/ci-run.webp)
+
+Breakage on any platform or backend is now caught automatically before any change gets merged. **For contributors, that's the real win**: you can open a pull request and **trust CI to prove it works everywhere**, instead of testing each platform by hand, which makes contributing a feature back to the engine far less daunting.
+
+A **gold-image generation workflow** runs **directly on CI**, so you no longer have to regenerate reference images by hand on every platform. Golds are produced and promoted straight from [the CI workflow](https://github.com/stride3d/stride/actions/workflows/test-gold-gen.yml).
+
+The new **CompareGold** tool makes reviewing these tests painless: visualize difference failures against their gold images, promote the ones you accept, and even pull results **directly from any CI run** or fork. For more information, check out [GPU Regression Testing](https://github.com/stride3d/stride/blob/master/tests/GPU-TESTING.md) in the engine repository docs.
+
+![CompareGold reviewing differences between pre-rendered and newly created images.](media/ReleaseNotes-4.4/compare-gold.webp)
 
 ## 💥 Breaking changes
 
-- **Custom shaders:** the SDSL compiler was rewritten; you might want to review how your custom shaders render. If you hit a shader that no longer compiles or behaves differently, please [open an issue on GitHub](https://github.com/stride3d/stride/issues) so we can fix it.
-- **Direct3D 12** now requires **Enhanced Barriers**; the legacy barrier path has been removed.
-- **Convex hulls**: The library we use to generate convex hulls, V-HACD, was updated. This new version improves on speed and accuracy, but has a wildly different set of configurable parameters; you may want to validate them for accuracy.
-- **Bepu `CharacterController` was reworked**: existing character setups will behave differently and need adjustment. See [Physics Character](#-physics-character).
+* **Custom shaders:** the SDSL compiler was rewritten, so you might want to review how your custom shaders render. If you have a shader that no longer compiles or behaves differently, please [open an issue on GitHub](https://github.com/stride3d/stride/issues) so we can fix it.
+* **Low-level graphics:** **Direct3D 12** now requires **Enhanced Barriers**. The legacy barrier path has been removed.
+* **Convex hulls:** the library we use to generate convex hulls (V-HACD) was updated. This new version improves on speed and accuracy, but has a wildly different set of configurable parameters, so you may want to validate them for accuracy.
+* **Bepu `CharacterController` was reworked:** existing character setups will behave differently and need adjustment. See [⚙️ Changes to the physics `CharacterComponent`](#-changes-to-the-physics-charactercomponent).
+* Dropped support for **32-bit** systems.
 
 ## 🙏 Contributors
 
 Thanks to everyone who contributed to this release:
 
 - [Acissathar](https://github.com/Acissathar)
-- [allcontributors[bot]](https://github.com/apps/allcontributors)
 - [azeno](https://github.com/azeno)
 - [Basewq](https://github.com/Basewq)
 - [D4rkDuck](https://github.com/D4rkDuck)
@@ -199,4 +195,4 @@ Welcome to our new contributors, who made their first contribution to the [strid
 - [steveberdy](https://github.com/steveberdy) made their first contribution in https://github.com/stride3d/stride/pull/3079
 - [Henr1k80](https://github.com/Henr1k80) made their first contribution in https://github.com/stride3d/stride/pull/3156
 
-..and everyone who reported issues, tested builds and helped on the community channels. 💙
+...and everyone who reported issues, tested builds and helped on the community channels. 💙

--- a/en/ReleaseNotes/ReleaseNotes.md
+++ b/en/ReleaseNotes/ReleaseNotes.md
@@ -26,7 +26,7 @@ You can now create, build and run Stride games entirely from the command line, w
 
 ```bash
 dotnet tool install -g stride.cli      # install the Stride CLI
-stride sdk install                     # install the latest Stride
+stride sdk install                     # install the latest version of Stride
 stride new topdownrpg && cd TopDownRPG # create a project from a template
 stride studio                          # open it in Game Studio
 ```

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/ci-run.png
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/ci-run.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:616ab589c23e64fc2a3a5fded3a54e628c81d46ee6710ec9c9135a024b16f054
-size 299726

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/ci-run.webp
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/ci-run.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a3cec1c6d85a14c5e283759731d90178c94c629cbd3dd4eea0b17f0cac04ae0
+size 86292

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/compare-gold.png
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/compare-gold.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8c33a5d114fbe65d98cab81cd31f07a483a5253a5d395f015e84b2022e8e26e
-size 246698

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/compare-gold.webp
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/compare-gold.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23391da603ec0429e8152fc35d1a1965e0d37b17f0e285627dba61352e856ec6
+size 51202

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/docs.webp
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/docs.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6501bf1879cb3d559da63d4844cc6313fd2338a97fe9c48da9df8cbf92f0222e
+size 118946

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/game-graphics-api-selector.png
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/game-graphics-api-selector.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a933a41fb2fbb9c85185ef0b61d5606d2e4d7b1a87881b8a7135a5b1a898d47
-size 604841

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/game-graphics-api-selector.webp
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/game-graphics-api-selector.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:703e7bc50fd033f03d6906768c1eaee496d11e9e56059c808213d9980e7e1b84
+size 24934

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/gamestudio-graphics-api-selector.png
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/gamestudio-graphics-api-selector.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fee03f88d1d6960706f86041b649b3d74d0d2338a4d1c501f6e6de747d39089d
-size 31208

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/ios.jpg
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/ios.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c12bd7b8ac564106b2fb8228a82101f6b6243b16ee9c12f5c4dd68a8e7e5763e
-size 196633

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/ios.webp
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/ios.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37f53536f61ef7ef71d44fb206553e64ef9b02b0e16a4593416d415e4f2c16d4
+size 69416

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/replacement-assets.webp
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/replacement-assets.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85aa0d222b832511bbd933960dc405cf923b3ecbb0eb3181bb2f2ea2a54d0867
+size 33874

--- a/en/ReleaseNotes/media/ReleaseNotes-4.4/stride-cli.png
+++ b/en/ReleaseNotes/media/ReleaseNotes-4.4/stride-cli.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b6fa18d9487e5bbc14a4309ea0ed5159ff505d7feac6d161d131d0a1644f0521
-size 20444


### PR DESCRIPTION
# Description
Adds many changes to 4.4 release notes:
* Added new assets and documentation sections
* Reworded text to be friendlier for non-technical users and less AI sounding
* Retook the screenshot of changing the game graphics API
* Added mention of removing 32-bit support
* Removed Stride CLI command table, due to it causing issues in the launcher
* Added links to relative docs pages where necessary
* Updated header structure
* Removed AI nonsense

# Important
I had difficulty with understanding some portions (mostly related to graphics and CI). I reworded them to be easier to understand, but it's likely that I may have gotten something wrong or removed crucial detail (it's had to tell if something is AI nonsense or something I just don't understand)
