### PR TITLE
chore: Removed notes that iOS is not supported from `video` and fixed videos going outside of pages

### DIFF
--- a/en/manual/video/index.md
+++ b/en/manual/video/index.md
@@ -6,13 +6,10 @@
 You can import **video files** and use them in your scenes.
 
 <p>
-<video autoplay loop class="responsive-video" poster="media/video-thumbnail.jpg">
+<video autoplay loop class="responsive-video ratio ratio-16x9 mb-3" poster="media/video-thumbnail.jpg">
    <source src="media/video-in-game.mp4" type="video/mp4">
 </video>
 </p>
-
->[!Note]
->Currently, Stride doesn't support video on iOS platforms.
 
 ## In this section
 

--- a/en/manual/video/set-up-a-video.md
+++ b/en/manual/video/set-up-a-video.md
@@ -5,16 +5,13 @@
 <span class="badge text-bg-success">Designer</span>
 
 <p>
-<video autoplay loop class="responsive-video" poster="media/video-thumbnail.jpg">
+<video autoplay loop class="responsive-video ratio ratio-16x9 mb-3" poster="media/video-thumbnail.jpg">
    <source src="media/video-in-game.mp4" type="video/mp4">
 </video>
 </p>
 
 >[!Note]
 >Stride supports most major video formats, but converts them to `.mp4`. To reduce compilation time, we recommend you use `.mp4` files so Stride doesn't have to convert them.
-
->[!Note]
->Currently, Stride doesn't support video on iOS platforms.
 
 ## 1. Add a video asset
 


### PR DESCRIPTION
This is how the videos in `video` used to look like before:

<img width="1574" height="1100" alt="image" src="https://github.com/user-attachments/assets/3f69418e-b049-4d32-908f-f67d3055d226" />

and this is how they look now:

<img width="1579" height="766" alt="image" src="https://github.com/user-attachments/assets/2384cea1-21f1-4cad-9fb8-21f0018f73a8" />
